### PR TITLE
Add D1 database binding and CF dev scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
+    "dev:cf": "wrangler dev --d1 DB=e5bfcb56-11ad-4288-a74c-3749f2ddfd1b",
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
@@ -13,7 +14,10 @@
     "lint:fix": "prettier --write .",
     "prepare": "svelte-kit sync || echo ''",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "db:migrate:local": "wrangler d1 execute DB --local --file schema.sql",
+    "db:migrate:prod": "wrangler d1 execute DB --remote --file schema.sql",
+    "deploy": "npm run build && npm run db:migrate:prod && wrangler pages deploy .svelte-kit/cloudflare"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^6.0.0",

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -6,7 +6,15 @@ declare global {
     // interface Locals {}
     // interface PageData {}
     // interface PageState {}
-    // interface Platform {}
+    interface Platform {
+      env: {
+        DB: D1Database;
+      };
+      context: {
+        waitUntil(promise: Promise<any>): void;
+      };
+      caches: CacheStorage;
+    }
   }
 }
 


### PR DESCRIPTION
This PR implements the two critical fixes requested by the engineering director:\n\n1. Updates src/app.d.ts to include Cloudflare Platform interface with D1Database binding (DB).\n2. Adds new scripts to package.json for local D1 development, migrations, and deployment (dev:cf, db:migrate:local, db:migrate:prod, deploy).\n\nNo other changes included.