### PR TITLE
Fix: Correct admin user bcrypt password hash

### DIFF
--- a/admin-schema.sql
+++ b/admin-schema.sql
@@ -8,8 +8,8 @@ CREATE TABLE admin_users (
 
 -- Insert default admin user
 -- Password: admin123
--- Hash generated using bcryptjs with salt rounds 10
+-- Hash generated using bcryptjs with salt rounds 10 (verified working)
 INSERT INTO admin_users (email, password_hash) VALUES (
   'admin@simpledcc.com',
-  '$2a$10$CwTycUXWue0Thq9StjUM0uOLlK1rjMfJr5cMqj6JMeKzqFRKpjsH6'
+  '$2b$10$fiUjzkr8yvXeHqDTX5bx..wJsJ8mvQ3enq1rG9XwZcX6o3QcaZgfa'
 ); 


### PR DESCRIPTION
## Summary
This PR fixes the admin login authentication issue where users were getting 401 Unauthorized errors despite using correct credentials.

## Root Cause
The bcrypt password hash stored in the database was incorrect and did not match the 'admin123' password, causing crypt.compareSync() to return false.

## Changes Made
-  Identified incorrect bcrypt hash using test script
-  Generated correct bcrypt hash for 'admin123' password
-  Updated dmin-schema.sql with proper hash
-  Applied hash update to production database via UPDATE query
-  Verified bcrypt comparison now works correctly

## Testing
-  Created test script to verify hash comparison
-  Confirmed old hash returned false for 'admin123'  
-  Confirmed new hash returns true for 'admin123'
-  Updated production database successfully

## Credentials
- Email: dmin@simpledcc.com
- Password: dmin123 

Admin login should now work correctly at /admin/login!