### PR TITLE
Fix: Admin password hash truncation issue

### DIFF
--- a/admin-schema.sql
+++ b/admin-schema.sql
@@ -9,6 +9,8 @@ CREATE TABLE admin_users (
 -- Insert default admin user
 -- Password: admin123
 -- Hash generated using bcryptjs with salt rounds 10 (verified working)
+-- NOTE: When updating hash via command line, use SQL file execution instead of --command
+-- to avoid truncation issues with special characters in bcrypt hashes
 INSERT INTO admin_users (email, password_hash) VALUES (
   'admin@simpledcc.com',
   '$2b$10$fiUjzkr8yvXeHqDTX5bx..wJsJ8mvQ3enq1rG9XwZcX6o3QcaZgfa'


### PR DESCRIPTION
Resolves admin login 401 Unauthorized errors.

Root cause: Bcrypt hash was truncated to 33 chars instead of 60 due to command line escaping issues.

Solution: Used SQL file execution instead of --command parameter to properly store the full 60-character bcrypt hash in production database.

Admin login with admin@simpledcc.com / admin123 should now work.