### PR TITLE
feat: Add admin dashboard statistics and manual trigger APIs

### DIFF
--- a/src/routes/api/admin/stats/+server.js
+++ b/src/routes/api/admin/stats/+server.js
@@ -1,0 +1,65 @@
+export async function GET({ platform, cookies }) {
+  // Check authentication
+  const session = cookies.get('admin_session');
+  if (session !== 'authenticated') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { 
+      status: 401,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+  
+  try {
+    // Get subscription count
+    const subscriptionCount = await platform?.env?.DB.prepare(
+      'SELECT COUNT(*) as count FROM subscriptions'
+    ).first();
+    
+    // Get unique dockets count
+    const docketCount = await platform?.env?.DB.prepare(
+      'SELECT COUNT(DISTINCT docket_number) as count FROM subscriptions'
+    ).first();
+    
+    // Get recent logs (limit 10)
+    const recentLogs = await platform?.env?.DB.prepare(
+      'SELECT * FROM system_logs ORDER BY created_at DESC LIMIT 10'
+    ).all();
+    
+    // Get top dockets by subscriber count
+    const topDockets = await platform?.env?.DB.prepare(`
+      SELECT docket_number, COUNT(*) as subscriber_count 
+      FROM subscriptions 
+      GROUP BY docket_number 
+      ORDER BY subscriber_count DESC 
+      LIMIT 5
+    `).all();
+    
+    const stats = {
+      totalSubscriptions: subscriptionCount?.count || 0,
+      activeDockets: docketCount?.count || 0,
+      recentLogs: recentLogs?.results || [],
+      topDockets: topDockets?.results || [],
+      systemHealth: 'healthy',
+      lastUpdated: new Date().toISOString()
+    };
+    
+    return new Response(JSON.stringify(stats), {
+      headers: { 'Content-Type': 'application/json' }
+    });
+  } catch (error) {
+    console.error('Stats API error:', error);
+    
+    // Log the error
+    try {
+      await platform?.env?.DB.prepare(
+        'INSERT INTO system_logs (level, message, component) VALUES (?, ?, ?)'
+      ).bind('error', `Stats API failed: ${error.message}`, 'admin-api').run();
+    } catch (logError) {
+      console.error('Failed to log error:', logError);
+    }
+    
+    return new Response(JSON.stringify({ error: 'Failed to load stats' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+} 

--- a/src/routes/api/admin/trigger/manual-check/+server.js
+++ b/src/routes/api/admin/trigger/manual-check/+server.js
@@ -1,0 +1,33 @@
+export async function POST({ platform, cookies }) {
+  // Check authentication
+  const session = cookies.get('admin_session');
+  if (session !== 'authenticated') {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { 
+      status: 401,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+  
+  try {
+    // Log the manual trigger
+    await platform?.env?.DB.prepare(
+      'INSERT INTO system_logs (level, message, component) VALUES (?, ?, ?)'
+    ).bind('info', 'Manual check triggered by admin', 'admin-trigger').run();
+    
+    // TODO: In Phase 2, this will actually trigger FCC API checks
+    // For now, just simulate success
+    
+    return new Response(JSON.stringify({ 
+      success: true, 
+      message: 'Manual check triggered (Phase 1 - placeholder)' 
+    }), {
+      headers: { 'Content-Type': 'application/json' }
+    });
+  } catch (error) {
+    console.error('Manual trigger error:', error);
+    return new Response(JSON.stringify({ error: 'Failed to trigger check' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+} 


### PR DESCRIPTION
- Add GET /api/admin/stats endpoint with subscription counts, docket counts, recent logs, and top dockets
- Add POST /api/admin/trigger/manual-check endpoint for manual FCC check triggers
- Both endpoints require admin authentication
- Include proper error handling and logging
- Phase 1 implementation with placeholder for Phase 2 FCC API integration