### PR TITLE
Remove "independent" from website banner

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -20,7 +20,7 @@
     <!-- Government Banner -->
     <div class="gov-banner">
       <div class="container">
-        🇺🇸 An independent FCC docket monitoring service - Not affiliated with the Federal Communications Commission
+        🇺🇸 An FCC docket monitoring service - Not affiliated with the Federal Communications Commission
       </div>
     </div>
     


### PR DESCRIPTION
Remove 'independent' from the website banner.