### PR TITLE
fix: update ECFS API to use platform.env instead of process.env

### DIFF
--- a/src/routes/api/admin/monitoring/trigger/+server.js
+++ b/src/routes/api/admin/monitoring/trigger/+server.js
@@ -35,7 +35,7 @@ export async function POST({ platform, cookies }) {
     
     // Perform ECFS check across all dockets
     const startTime = Date.now();
-    const ecfsResult = await fetchMultipleDockets(docketNumbers, 2); // 2 hour lookback
+    const ecfsResult = await fetchMultipleDockets(docketNumbers, 2, platform.env); // Pass platform.env for API key
     const endTime = Date.now();
     
     // Store new filings


### PR DESCRIPTION
## Problem
The ECFS API integration was failing with 403 errors because it was trying to access process.env.ECFS_API_KEY instead of platform.env.ECFS_API_KEY in the Cloudflare Workers environment.

## Solution
- Updated etchECFSFilings() to accept env parameter and use env.ECFS_API_KEY
- Updated etchMultipleDockets() to pass env parameter through
- Updated monitoring trigger endpoint to pass platform.env to ECFS functions
- Added API key validation with clear error messages
- Added debug logging with sanitized API keys

## Testing
- Set ECFS_API_KEY as secret in Cloudflare Pages environment variables
- After merge, test via Admin  Monitoring  Trigger Manual Check
- Should see successful ECFS API calls instead of 403 errors

## Expected Results
 No more 403 errors from ECFS API
 Debug logs showing sanitized ECFS URLs  
 Successful filing retrieval for monitored dockets
 Clear error if API key missing

Resolves ECFS API key configuration issue for Cloudflare Pages deployment.