### PR TITLE
fix: support both authentication methods in migration API

### DIFF
--- a/src/routes/api/admin/database/schema-check/+server.js
+++ b/src/routes/api/admin/database/schema-check/+server.js
@@ -7,16 +7,27 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Admin-Key',
 };
 
-export async function GET({ platform, cookies }) {
+export async function GET({ platform, cookies, request }) {
   try {
-    // Verify admin authentication
-    const adminSession = cookies.get('admin_session');
-    if (adminSession !== 'authenticated') {
-      return json({ error: 'Unauthorized' }, { status: 401, headers: corsHeaders });
-    }
-
     const db = platform.env.DB;
     
+    // Support both authentication methods:
+    // 1. Cookie-based (for admin UI)
+    // 2. Header-based (for curl/API calls)  
+    const adminSession = cookies.get('admin_session');
+    const adminKeyHeader = request.headers.get('x-admin-key');
+    const adminSecretKey = platform.env.ADMIN_SECRET_KEY;
+    
+    const isAuthenticatedViaCookie = adminSession === 'authenticated';
+    const isAuthenticatedViaHeader = adminKeyHeader && adminKeyHeader === adminSecretKey;
+    
+    if (!isAuthenticatedViaCookie && !isAuthenticatedViaHeader) {
+      return json({ 
+        error: 'Unauthorized',
+        details: 'Provide either valid admin session cookie or x-admin-key header'
+      }, { status: 401, headers: corsHeaders });
+    }
+
     // Check database schema without running migration
     console.log('📋 Checking database schema...');
     const schemaResult = await checkDatabaseSchema(db);


### PR DESCRIPTION
## Problem
The engineering director's curl command was failing because I changed the migration API to only support cookie-based authentication, but the curl command uses header-based authentication with x-admin-key.

## Solution  
Updated both migration endpoints to support BOTH authentication methods:

### Cookie-Based Auth (Admin UI)
- Works with admin dashboard after login
- Uses session cookies automatically

### Header-Based Auth (API Calls)  
- Works with curl commands and direct API access
- Uses x-admin-key header with ADMIN_SECRET_KEY

## Files Updated
- src/routes/api/admin/database/migrate/+server.js - Dual auth support
- src/routes/api/admin/database/schema-check/+server.js - Consistency

## Testing Instructions
1. Merge this PR 
2. Run the curl command your director provided
3. Should get successful migration response
4. Admin UI continues to work as before

This resolves the authentication compatibility issue!