### PR TITLE
fix: Resolve cron-worker Cloudflare Workers deployment issue

### DIFF
--- a/cron-worker/src/lib/fcc/ecfs-enhanced-client.js
+++ b/cron-worker/src/lib/fcc/ecfs-enhanced-client.js
@@ -1,5 +1,3 @@
-import { env } from '$env/dynamic/private';
-
 // Enhanced ECFS Client - Last 50 Filings Approach with Direct Document Access
 // Based on successful API test: https://publicapi.fcc.gov/ecfs/filings?api_key=...
 
@@ -10,17 +8,16 @@ const DEFAULT_LIMIT = 50; // Get last 50 filings per docket
  * Enhanced ECFS client with direct document URL access
  * @param {string} docketNumber - FCC docket number (e.g., '07-114')
  * @param {number} limit - Number of recent filings to fetch (default: 50)
- * @param {Object} passedEnv - Environment variables passed from caller (optional)
+ * @param {Object} env - Environment variables passed from caller
  * @returns {Promise<Array>} Array of filing objects with direct document URLs
  */
-export async function fetchLatestFilings(docketNumber, limit = DEFAULT_LIMIT, passedEnv) {
+export async function fetchLatestFilings(docketNumber, limit = DEFAULT_LIMIT, env) {
   try {
-    // Use SvelteKit native env with fallback support for backwards compatibility
-    const apiKey = env.ECFS_API_KEY || passedEnv?.ECFS_API_KEY || process.env.ECFS_API_KEY;
+    // Use the passed environment object
+    const apiKey = env.ECFS_API_KEY || process.env.ECFS_API_KEY;
     if (!apiKey) {
       console.error('🔍 Environment check:', {
-        svelteKitEnvHasKey: !!env.ECFS_API_KEY,
-        passedEnvKeys: passedEnv ? Object.keys(passedEnv) : 'passedEnv is null',
+        envHasKey: !!env.ECFS_API_KEY,
         processEnvHasKey: !!process.env.ECFS_API_KEY,
         nodeEnv: process.env.NODE_ENV
       });


### PR DESCRIPTION
Fix SvelteKit import issue in cron-worker that was preventing Cloudflare Workers deployment.

Problem: cron-worker was importing '/dynamic/private' which doesn't exist in Cloudflare Workers runtime.

Solution: 
- Removed SvelteKit-specific import from ecfs-enhanced-client.js
- Updated fetchLatestFilings function to use env parameter properly
- Follows Cloudflare Workers best practices for environment variables

Result:
- Cron-worker now builds and deploys successfully to Cloudflare Workers
- All Card 4 functionality (System Health Dashboard & Tier-Based Emails) remains intact
- Production deployment ready

Files changed: cron-worker/src/lib/fcc/ecfs-enhanced-client.js