### PR TITLE
enhance: Bypass active dockets validation for manual triggers

### DIFF
--- a/cron-worker/src/index.ts
+++ b/cron-worker/src/index.ts
@@ -223,23 +223,10 @@ async function runDataPipeline(env: any, ctx: any, isManualTrigger = false, targ
           };
         }
         
-        // Check if docket exists in active dockets
-        const docketExists = activeDockets.find(d => d.docket_number === targetDocket);
-        if (!docketExists) {
-          addLog('error', 'Requested docket not found in active dockets', { 
-            requested: targetDocket,
-            available: activeDockets.map(d => d.docket_number)
-          });
-          return {
-            success: false,
-            error: `Docket ${targetDocket} not found in active dockets. Available: ${activeDockets.map(d => d.docket_number).join(', ')}`,
-            logs: logEntries
-          };
-        }
-        
-        // Use only the requested docket
-        testDockets = [docketExists];
-        addLog('info', `🎯 Manual trigger: Processing specific docket ${targetDocket}`);
+        // For manual triggers, bypass active dockets check and test any docket
+        // This allows testing/debugging of any docket that exists on FCC ECFS
+        testDockets = [{ docket_number: targetDocket }];
+        addLog('info', `🎯 Manual trigger: Testing docket ${targetDocket} (bypassing active dockets validation)`);
         
       } else {
         // Backward compatibility: default to 02-10 if no docket specified


### PR DESCRIPTION
## Summary
This PR removes the active dockets validation requirement for manual triggers, allowing testing and debugging of any docket that exists on FCC ECFS, not just those in the subscription system.

## Problem Solved
- **Before**: Manual trigger required dockets to exist in active_dockets table
- **After**: Manual trigger can test any valid FCC docket (bypasses database validation)

## Key Changes
### Cloudflare Worker (cron-worker/src/index.ts)
- **Remove active dockets check**: No longer requires docket to exist in active_dockets table
- **Keep format validation**: Still validates XX-XX docket pattern for safety
- **Enhanced logging**: Clear messages about bypassing validation
- **Maintains safety**: Filing limits and other constraints still apply

## Use Case
Enables testing dockets like 25-143 that exist on FCC but aren't in the subscription system. Perfect for:
- **Debugging**: Investigate any FCC docket issues
- **Testing**: Validate pipeline with various docket types
- **Exploration**: Test new dockets before adding to subscription system

## Safety Analysis
 **No downstream issues identified**:
- Filing storage uses docket_number as string (no foreign key constraints)
- Statistics updates gracefully handle non-existent dockets
- Notification system only affects subscribed users
- Production cron jobs unchanged (still use active dockets)

## Testing
-  Deployed to production Cloudflare Worker
-  Manual production test page now works with any valid FCC docket
-  Maintains backward compatibility (defaults to 02-10)
-  Clear error handling for invalid docket formats

## Impact
- **Manual triggers**: Can now test any FCC docket
- **Production cron**: Unchanged behavior (still uses active dockets)
- **Error handling**: Better messages for debugging
- **Flexibility**: Full testing capability for any valid docket

This resolves the blocker preventing testing of dockets not in the subscription system.