### PR TITLE
fix: Disable runaway seed processing and add missing database column

### DIFF
--- a/cron-worker/src/index.ts
+++ b/cron-worker/src/index.ts
@@ -13,6 +13,10 @@ import { processFilingBatchEnhanced } from './lib/ai/gemini-enhanced';
  * @returns {Promise<Object>} Seeding results
  */
 async function processSeedSubscriptions(env: any) {
+  // TEMPORARY FIX: Disable seed processing to prevent runaway API calls
+  console.log('🌱 Seed processing temporarily disabled to prevent subrequest limit issues');
+  return { processed: 0, sent: 0, errors: [] };
+  
   const startTime = Date.now();
   
   try {

--- a/migrations/009_fix_notification_queue_filing_data.sql
+++ b/migrations/009_fix_notification_queue_filing_data.sql
@@ -1,0 +1,8 @@
+-- Fix for seed processing: Add missing filing_data column
+-- This column is used by processSeedSubscriptions to store filing data JSON
+-- The table currently only has filing_ids which stores an array of IDs
+
+ALTER TABLE notification_queue ADD COLUMN filing_data TEXT;
+
+-- Update existing rows to have empty filing_data if needed
+UPDATE notification_queue SET filing_data = '{}' WHERE filing_data IS NULL; 


### PR DESCRIPTION
## Summary

This PR implements an immediate fix to stop the runaway seed processing that's causing cron-worker failures.

## Problem
- Seed processing was hitting Cloudflare's 50 subrequest limit
- Processing non-monitored dockets (33-33, 13-1, etc.) 
- Missing iling_data column causing database errors
- Excessive API calls to Jina and Gemini

## Solution
### 1. Database Fix (1.1)
- Added migration 