### PR TITLE
fix: Fix database viewer pagination

### DIFF
--- a/src/routes/admin/database-viewer/+page.svelte
+++ b/src/routes/admin/database-viewer/+page.svelte
@@ -279,8 +279,8 @@
 			
 			const data = await response.json();
 			tableData = data.data || [];
-			totalPages = data.pagination?.totalPages || 1;
-			totalRows = data.pagination?.totalRows || 0;
+			totalPages = data.totalPages || 1;
+			totalRows = data.total || 0;
 			lastRefreshTime = new Date();
 		} catch (err) {
 			error = err.message;


### PR DESCRIPTION
Fixes pagination issue where 193 filings were loaded but only 50 displayed. Updated frontend to correctly read API response structure (total/totalPages instead of pagination.totalRows/totalPages).