### PR TITLE
fix: Resolve seeding NOT NULL constraint and system_health_logs schema issues

### DIFF
--- a/cron-worker/src/lib/database/auto-migration.js
+++ b/cron-worker/src/lib/database/auto-migration.js
@@ -10,6 +10,7 @@ const REQUIRED_SCHEMA = {
   filings: ['id', 'docket_number', 'title', 'author', 'filing_type', 'date_received', 'filing_url', 'documents', 'raw_data', 'ai_summary', 'status', 'created_at', 'processed_at'],
   active_dockets: ['docket_number', 'last_checked', 'total_filings', 'subscribers_count', 'status', 'error_count', 'created_at', 'updated_at'],
   system_logs: ['id', 'level', 'message', 'component', 'details', 'docket_number', 'filing_id', 'created_at'],  // Added missing columns!
+  system_health_logs: ['id', 'timestamp', 'level', 'message', 'category', 'details', 'docket_number', 'filing_id', 'created_at', 'service_name', 'status', 'run_timestamp', 'duration_ms', 'metrics', 'error_message', 'error_stack'],  // Health monitoring table
   notification_queue: ['id', 'email', 'docket_number', 'filing_ids', 'digest_type', 'status', 'created_at', 'sent_at', 'error_message']
 };
 
@@ -379,6 +380,15 @@ function getColumnType(tableName, columnName) {
     'system_logs': {
       'docket_number': 'TEXT',           // Optional docket context
       'filing_id': 'TEXT'                // Optional filing context
+    },
+    'system_health_logs': {
+      'service_name': 'TEXT',
+      'status': 'TEXT',
+      'run_timestamp': 'INTEGER',
+      'duration_ms': 'INTEGER',
+      'metrics': 'TEXT',
+      'error_message': 'TEXT',
+      'error_stack': 'TEXT'
     },
     'subscriptions': {
       'frequency': 'TEXT DEFAULT \'daily\'',

--- a/cron-worker/src/lib/seeding/seed-operations.js
+++ b/cron-worker/src/lib/seeding/seed-operations.js
@@ -115,11 +115,12 @@ export async function handleImmediateSeeding(docketNumber, userEmail, userTier, 
 
     // Queue seed digest
     await db.prepare(`
-      INSERT INTO notification_queue (user_email, docket_number, digest_type, filing_data, created_at)
-      VALUES (?, ?, 'seed_digest', ?, ?)
+      INSERT INTO notification_queue (user_email, docket_number, digest_type, filing_ids, filing_data, created_at)
+      VALUES (?, ?, 'seed_digest', ?, ?, ?)
     `).bind(
       userEmail,
       docketNumber,
+      JSON.stringify([seedFiling.id]), // Include filing ID for consistency
       JSON.stringify({ 
         filings: [seedFiling], 
         tier: userTier 

--- a/migrations/013_fix_system_health_logs_schema.sql
+++ b/migrations/013_fix_system_health_logs_schema.sql
@@ -1,0 +1,22 @@
+-- Migration 013: Fix System Health Logs Schema
+-- Add missing columns that cron worker expects
+
+-- Add the missing columns that the cron worker is trying to use
+ALTER TABLE system_health_logs ADD COLUMN service_name TEXT;
+ALTER TABLE system_health_logs ADD COLUMN status TEXT;
+ALTER TABLE system_health_logs ADD COLUMN run_timestamp INTEGER;
+ALTER TABLE system_health_logs ADD COLUMN duration_ms INTEGER;
+ALTER TABLE system_health_logs ADD COLUMN metrics TEXT;
+ALTER TABLE system_health_logs ADD COLUMN error_message TEXT;
+ALTER TABLE system_health_logs ADD COLUMN error_stack TEXT;
+
+-- Create indexes for the new columns for performance
+CREATE INDEX IF NOT EXISTS idx_system_health_logs_service_name ON system_health_logs(service_name);
+CREATE INDEX IF NOT EXISTS idx_system_health_logs_status ON system_health_logs(status);
+CREATE INDEX IF NOT EXISTS idx_system_health_logs_run_timestamp ON system_health_logs(run_timestamp);
+
+-- Log the migration completion
+INSERT INTO system_logs (level, message, component, details, created_at)
+VALUES ('info', 'Migration 013: Added missing columns to system_health_logs table', 'migration', 
+        '{"columns_added": ["service_name", "status", "run_timestamp", "duration_ms", "metrics", "error_message", "error_stack"]}', 
+        unixepoch()); 

--- a/src/lib/database/auto-migration.js
+++ b/src/lib/database/auto-migration.js
@@ -10,6 +10,7 @@ const REQUIRED_SCHEMA = {
   filings: ['id', 'docket_number', 'title', 'author', 'filing_type', 'date_received', 'filing_url', 'documents', 'raw_data', 'ai_summary', 'status', 'created_at', 'processed_at'],
   active_dockets: ['docket_number', 'last_checked', 'total_filings', 'subscribers_count', 'status', 'error_count', 'created_at', 'updated_at'],
   system_logs: ['id', 'level', 'message', 'component', 'details', 'docket_number', 'filing_id', 'created_at'],  // Added missing columns!
+  system_health_logs: ['id', 'timestamp', 'level', 'message', 'category', 'details', 'docket_number', 'filing_id', 'created_at', 'service_name', 'status', 'run_timestamp', 'duration_ms', 'metrics', 'error_message', 'error_stack'],  // Health monitoring table
   notification_queue: ['id', 'email', 'docket_number', 'filing_ids', 'digest_type', 'status', 'created_at', 'sent_at', 'error_message']
 };
 
@@ -379,6 +380,15 @@ function getColumnType(tableName, columnName) {
     'system_logs': {
       'docket_number': 'TEXT',           // Optional docket context
       'filing_id': 'TEXT'                // Optional filing context
+    },
+    'system_health_logs': {
+      'service_name': 'TEXT',
+      'status': 'TEXT',
+      'run_timestamp': 'INTEGER',
+      'duration_ms': 'INTEGER',
+      'metrics': 'TEXT',
+      'error_message': 'TEXT',
+      'error_stack': 'TEXT'
     },
     'subscriptions': {
       'frequency': 'TEXT DEFAULT \'daily\'',


### PR DESCRIPTION
## Issues Fixed

This PR resolves two critical production issues identified in the cron-worker:

### Issue 1: Seeding NOT NULL Constraint Failure 
**Problem**: The seeding function was inserting into 
otification_queue without providing the required iling_ids column, causing:
`
NOT NULL constraint failed: notification_queue.filing_ids: SQLITE_CONSTRAINT
`

**Fix**: Updated cron-worker/src/lib/seeding/seed-operations.js to include iling_ids in the INSERT statement with the seed filing ID as a JSON array.

### Issue 2: Missing Database Column 
**Problem**: System health logging was failing with:
`
no such column: system_health_logs.service_name: SQLITE_ERROR
`

**Fix**: Created migration 013 to add the missing columns that the cron-worker expects:
- service_name
- status 
- un_timestamp
- duration_ms
- metrics
- error_message
- error_stack

## Changes Made

1. **Migration 013**: migrations/013_fix_system_health_logs_schema.sql
   - Adds missing columns to system_health_logs table
   - Creates performance indexes for new columns

2. **Seeding Function Fix**: cron-worker/src/lib/seeding/seed-operations.js
   - Includes iling_ids column in notification_queue INSERT
   - Provides seed filing ID as JSON array for consistency

3. **Auto-Migration Updates**: Both cron-worker and src auto-migration files
   - Updated REQUIRED_SCHEMA to include system_health_logs with all expected columns
   - Added column type definitions for new fields

## Deployment Process

**Recommended sequence**:
1. Merge this PR
2. Deploy updated cron-worker code (wrangler deploy)
3. Apply migration 013 to production database
4. Verify health logging and seeding work correctly

## Testing

-  Cron-worker compiles successfully
-  Seeding function includes required filing_ids column
-  Auto-migration schemas updated consistently
-  Local testing limited due to empty simulated database (expected)

Resolves the production seeding failures and system health logging errors.