### PR TITLE
fix: restore document extraction in AI processing pipeline

### DIFF
--- a/cron-worker/src/lib/documents/jina-processor.js
+++ b/cron-worker/src/lib/documents/jina-processor.js
@@ -2,6 +2,29 @@
 // UNIFIED JINA APPROACH: Robust handling of both JSON and plain text responses
 
 /**
+ * WRAPPER FUNCTION FOR AI PROCESSING COMPATIBILITY
+ * Extract text content from a single document URL - used by AI processing
+ * @param {string} url - Document URL to extract text from
+ * @param {Object} env - Environment variables object
+ * @returns {Promise<string>} Extracted text content
+ */
+export async function extractDocumentContent(url, env) {
+  try {
+    console.log(`🔗 AI Processing: Extracting content from ${url}`);
+    const result = await extractTextFromHTML(url, env);
+    
+    // Sanitize text to remove "undefined" artifacts
+    const sanitizedText = result.text.replace(/undefined/g, '');
+    console.log(`✅ AI Processing: Extracted ${sanitizedText.length} characters via ${result.extraction_strategy}`);
+    
+    return sanitizedText;
+  } catch (error) {
+    console.error(`❌ AI Processing: Failed to extract content from ${url}:`, error.message);
+    throw error;
+  }
+}
+
+/**
  * Extract text from any URL using unified Jina approach with intelligent response handling
  * Handles both direct PDFs and HTML viewer URLs
  * @param {string} url - URL like "https://docs.fcc.gov/public/attachments/file.pdf" or "https://www.fcc.gov/ecfs/document/ID/1"


### PR DESCRIPTION
## Problem
AI processing was failing with extractDocumentContent is not a function error because this function was missing from jina-processor.js after recent refactoring.

## Root Cause
The AI processing code (gemini-enhanced.js) expects an extractDocumentContent(url, env) function that returns extracted text content, but only processFilingDocuments was exported from jina-processor.js.

## Solution
- Added missing extractDocumentContent wrapper function to cron-worker/src/lib/documents/jina-processor.js
- Function uses existing extractTextFromHTML internally with proper parameter mapping
- Includes text sanitization to remove 'undefined' artifacts from Jina API responses
- Maintains existing functionality while restoring AI processing compatibility

## Expected Results
-  Document extraction should work in AI processing
-  documentsProcessed should be > 0 in manual production tests  
-  No more 'extractDocumentContent is not a function' errors
-  AI processing pipeline should be fully functional

## Testing
Test using /admin/manual-production-test with docket 11-42 and verify:
1. Document processing section shows successful extractions
2. AI analysis shows documentsProcessed > 0
3. No function-related errors in logs

Fixes the final step needed to restore full SimpleDCC functionality.