### PR TITLE
Implement confidential filing detection and handling

### DIFF
--- a/cron-worker/src/lib/ai/gemini-enhanced.js
+++ b/cron-worker/src/lib/ai/gemini-enhanced.js
@@ -288,6 +288,30 @@ export async function processFilingEnhanced(filing, env) {
       };
     }
 
+    // Early detection: Handle confidential/restricted filings
+    if (filing.is_filing_restricted) {
+      console.log(`🔒 Filing ${filing.id} marked as restricted (${filing.restriction_reason}) - providing confidential filing response`);
+      
+      return {
+        ...filing,
+        ai_enhanced: true,
+        ai_summary: `This filing (${filing.title}) contains confidential documents that are not publicly accessible.`,
+        ai_key_points: [
+          `Filing marked as: ${filing.restriction_reason}`,
+          "Document content not available for public analysis",
+          "Filing details may only be viewable by authorized parties"
+        ],
+        ai_stakeholders: "Cannot determine - confidential filing restrictions apply",
+        ai_regulatory_impact: "Cannot assess - document content restricted from public access",
+        ai_document_analysis: "Document analysis not possible due to confidentiality restrictions",
+        ai_confidence: `This filing is marked as "${filing.restriction_reason}" in the FCC ECFS system, making document content inaccessible for AI analysis. Filing metadata and basic information remain publicly viewable.`,
+        documents_processed: 0,
+        status: 'completed_restricted',
+        processing_mode: 'confidential_handling',
+        processed_at: Date.now()
+      };
+    }
+
     console.log(`🤖 Enhanced processing filing: ${filing.id} - ${filing.title}`);
     
     // Process documents if available

--- a/cron-worker/src/lib/fcc/ecfs-enhanced-client.js
+++ b/cron-worker/src/lib/fcc/ecfs-enhanced-client.js
@@ -80,6 +80,10 @@ function transformFilingEnhanced(rawFiling, docketNumber) {
     console.warn('⚠️ Filing missing id_submission:', rawFiling);
   }
 
+  // Parse viewing status for confidential document handling
+  const viewingStatus = rawFiling.viewingstatus || [];
+  const isRestricted = isFilingRestricted(viewingStatus);
+
   const filing = {
     // Use id_submission for perfect deduplication (key improvement!)
     id: rawFiling.id_submission,
@@ -117,6 +121,11 @@ function transformFilingEnhanced(rawFiling, docketNumber) {
     // 🔥 GAME CHANGER: Direct document URLs from successful API test
     documents: extractDocumentsEnhanced(rawFiling),
     
+    // NEW: Viewing status and confidentiality handling
+    viewing_status: viewingStatus,
+    is_filing_restricted: isRestricted,
+    restriction_reason: isRestricted ? viewingStatus.map(vs => vs.description || 'Unknown restriction').join(', ') : null,
+    
     // Enhanced metadata
     submitter_info: {
       name: rawFiling.name_of_filer || rawFiling.filer_name,
@@ -147,11 +156,43 @@ function transformFilingEnhanced(rawFiling, docketNumber) {
 }
 
 /**
+ * Helper function to determine if filing has restricted viewing status
+ * @param {Array} viewingStatus - Array of viewing status objects from ECFS API
+ * @returns {boolean} True if filing is restricted/confidential
+ */
+function isFilingRestricted(viewingStatus) {
+  if (!viewingStatus || !Array.isArray(viewingStatus) || viewingStatus.length === 0) {
+    return false;
+  }
+  
+  return viewingStatus.some(status => {
+    if (!status.description) return false;
+    
+    const description = status.description.toLowerCase();
+    return description.includes('confidential') || 
+           description.includes('restricted') || 
+           description.includes('sealed') ||
+           description.includes('private');
+  });
+}
+
+/**
  * Extract documents with direct download URLs (proven from API test)
  */
 function extractDocumentsEnhanced(rawFiling) {
   try {
     const documents = rawFiling.documents || [];
+    
+    // Check if filing has restricted viewing status
+    const viewingStatus = rawFiling.viewingstatus || [];
+    const isFilingRestricted = viewingStatus.some(status => {
+      if (!status.description) return false;
+      const description = status.description.toLowerCase();
+      return description.includes('confidential') || 
+             description.includes('restricted') || 
+             description.includes('sealed') ||
+             description.includes('private');
+    });
     
     // Document structure logging removed for production efficiency
     
@@ -160,7 +201,15 @@ function extractDocumentsEnhanced(rawFiling) {
       src: doc.src, // 🎯 DIRECT PDF URL! (e.g., "https://docs.fcc.gov/public/attachments/DA-25-567A1.pdf")
       description: doc.description || '',
       type: getFileType(doc.filename),
-      downloadable: !!doc.src && doc.src.includes('fcc.gov'),
+      downloadable: !!doc.src && doc.src.includes('fcc.gov') && !isFilingRestricted,
+      
+      // NEW: Confidentiality markers
+      is_confidential: isFilingRestricted,
+      access_restricted: !doc.src || isFilingRestricted,
+      restriction_reason: isFilingRestricted ? 
+        viewingStatus.map(vs => vs.description || 'Unknown restriction').join(', ') : 
+        (!doc.src ? 'No source URL provided' : null),
+      
       size_estimate: estimateFileSize(doc.filename)
     }));
     


### PR DESCRIPTION
This PR addresses the issue where the system was wasting API calls and producing misleading error messages when processing confidential/restricted FCC filings. The Marshalltown filing example showed our system processing documents that had no accessible content due to confidential status, burning Jina/Gemini API calls on inaccessible PDFs, and producing confusing AI summary messages for restricted content. Key changes include: (1) Added viewingstatus field parsing from FCC API responses with new filing fields for viewing_status, is_filing_restricted, and restriction_reason. (2) Early detection that skips document processing for restricted filings before API calls, preventing wasted Jina processing on inaccessible content. (3) Intelligent AI responses for confidential content that prevent Gemini calls on content known to be inaccessible. (4) Enhanced document metadata with confidentiality flags and processing method tracking. The implementation uses defensive programming with safe handling of missing viewingstatus fields, maintains backward compatibility, uses existing JSON fields without database changes, and preserves expected object structures. This fix directly addresses the inefficiencies seen in recent BAU logs where filings consumed resources without providing value.