### PR TITLE
docs: Update Stripe environment variables documentation

### DIFF
--- a/STRIPE_INTEGRATION_ARCHITECTURE.md
+++ b/STRIPE_INTEGRATION_ARCHITECTURE.md
@@ -251,3 +251,34 @@ Identical functions replicated in `cron-worker/src/lib/users/user-operations.ts`
 **Last Updated**: January 2025  
 **Integration Status**: Fully Implemented  
 **Production Ready**: Yes (pending final environment variable configuration) 
+
+---
+
+## Environment Variables Update (January 2025)
+
+### Critical Variables Added for Production Fix
+
+The following environment variables were added to resolve Stripe integration issues:
+
+1. **VITE_STRIPE_PUBLISHABLE_KEY**
+   - Same value as STRIPE_PUBLISHABLE_KEY but with VITE_ prefix
+   - Required for SvelteKit frontend access to Stripe publishable key
+   - Example: pk_test_1234567890abcdef
+
+2. **PUBLIC_ORIGIN** 
+   - Production domain URL for Stripe redirects and webhooks
+   - Format: https://your-domain.com
+   - Example: https://simpledcc.pages.dev
+
+### Configuration Steps
+1. Add both variables to Cloudflare Pages environment settings
+2. Ensure VITE_STRIPE_PUBLISHABLE_KEY matches STRIPE_PUBLISHABLE_KEY value
+3. Set PUBLIC_ORIGIN to actual production domain
+4. Redeploy application to activate changes
+
+### Troubleshooting
+- Use /admin/stripe-diagnostics to verify all environment variables
+- "Environment Variables Check Failed" indicates missing VITE_ or PUBLIC_ORIGIN variables
+- Environment variable changes require full redeployment
+
+**Last Updated**: January 2025 - Environment variables configuration fix


### PR DESCRIPTION
##  Stripe Environment Variables Documentation Update

This PR documents the critical environment variables that were added to fix production Stripe integration issues.

###  **Problem Addressed:**
- Production Stripe diagnostics failing due to missing environment variables
- VITE_STRIPE_PUBLISHABLE_KEY and PUBLIC_ORIGIN were not documented
- Need clear configuration guidance for Cloudflare Pages deployment

###  **Documentation Added:**

#### New Environment Variables Documented:
1. **VITE_STRIPE_PUBLISHABLE_KEY**
   - Frontend-accessible version of Stripe publishable key
   - Requires VITE_ prefix for SvelteKit client-side access
   - Same value as STRIPE_PUBLISHABLE_KEY

2. **PUBLIC_ORIGIN**
   - Production domain URL for Stripe redirects and webhooks
   - Format: https://your-domain.com
   - Example: https://simpledcc.pages.dev

#### Troubleshooting Guide Added:
- Common configuration errors and solutions
- Environment Variables Check Failed troubleshooting
- Deployment requirements for environment variable changes
- Reference to /admin/stripe-diagnostics for validation

###  **Configuration Steps Documented:**
1. Add variables to Cloudflare Pages environment settings
2. Ensure VITE_STRIPE_PUBLISHABLE_KEY matches STRIPE_PUBLISHABLE_KEY
3. Set PUBLIC_ORIGIN to production domain
4. Redeploy to activate changes

###  **Expected Result:**
After merging and deploying, the Stripe diagnostics system should pass the Environment Variables check, enabling proper diagnosis of any remaining Stripe integration issues.

This documentation will help prevent similar configuration issues in the future.