### PR TITLE
Fix checkout-session diagnostic process.env error

### DIFF
--- a/src/routes/api/admin/stripe-diagnostics/checkout-session/+server.ts
+++ b/src/routes/api/admin/stripe-diagnostics/checkout-session/+server.ts
@@ -45,9 +45,9 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 
     // Step 2: Environment variables validation
     logStep('Environment variables validation');
-    const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
-    const stripePriceId = process.env.STRIPE_PRO_PRICE_ID;
-    const publicOrigin = process.env.PUBLIC_ORIGIN;
+    const stripeSecretKey = platform.env.STRIPE_SECRET_KEY;
+    const stripePriceId = platform.env.STRIPE_PRO_PRICE_ID;
+    const publicOrigin = platform.env.PUBLIC_ORIGIN;
 
     const envValidation = {
       STRIPE_SECRET_KEY: !!stripeSecretKey,


### PR DESCRIPTION
Fixes remaining 'process is not defined' error in Stripe diagnostics Step 8.

Changed process.env to platform.env in checkout-session diagnostic endpoint for Cloudflare Pages compatibility.

This should make all Stripe diagnostic steps pass successfully.