### PR TITLE
Fix: Webhook test endpoint process.env error for Cloudflare compatibility

### DIFF
--- a/src/routes/api/admin/stripe-diagnostics/webhook-test/+server.ts
+++ b/src/routes/api/admin/stripe-diagnostics/webhook-test/+server.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from './$types';
 import { json } from '@sveltejs/kit';
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ request, platform }) => {
   try {
     const { adminSecret } = await request.json();
     
@@ -9,8 +9,8 @@ export const POST: RequestHandler = async ({ request }) => {
       return json({ error: 'Admin secret required' }, { status: 401 });
     }
 
-    const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
-    const publicOrigin = process.env.PUBLIC_ORIGIN;
+    const webhookSecret = platform?.env?.STRIPE_WEBHOOK_SECRET;
+    const publicOrigin = platform?.env?.PUBLIC_ORIGIN;
     
     // Test webhook endpoint accessibility
     const webhookUrl = `${publicOrigin || 'https://your-domain.com'}/api/stripe/webhook`;


### PR DESCRIPTION
Problem: Step 8 Webhook Testing was failing with process is not defined error. Solution: Updated webhook test endpoint to use platform.env instead of process.env for Cloudflare compatibility. This fixes the diagnostic test while maintaining the working webhook flow.