### PR TITLE
Move email lookup functionality from /manage to admin/monitoring

### DIFF
--- a/-la FrequencyToggle_Classic.svelte FrequencyToggle_Creative.svelte FrequencyToggle_SaaS.svelte
+++ b/-la FrequencyToggle_Classic.svelte FrequencyToggle_Creative.svelte FrequencyToggle_SaaS.svelte
@@ -1,0 +1,8 @@
+[33m4435a7b[m[33m ([m[1;36mHEAD[m[33m -> [m[1;32mfix/direct-upgrade-update[m[33m, [m[1;31morigin/fix/direct-upgrade-update[m[33m)[m fix: implement direct synchronous upgrade update to fix race condition
+[33m9287055[m[33m ([m[1;31morigin/master[m[33m, [m[1;31morigin/HEAD[m[33m, [m[1;32mmaster[m[33m)[m fix: implement robust webhook handler for authenticated upgrades (#133)
+[33m42fb6e3[m feat: implement authenticated user Pro upgrade flow (#132)
+[33m9c54971[m[33m ([m[1;32mfix/upgrade-link-loop[m[33m)[m fix: Resolve free subscription signup error (#131)
+[33m0871680[m feat: Add dashboard docket management with user detection (#130)
+[33m8f39b71[m Fix session cookie issue after Stripe payment (#129)
+[33m8310372[m HOTFIX: Comprehensive Stripe integration fixes (#128)
+[33mb7aeae2[m Implement Pending Signup Flow - Complete 9-Step Implementation (#127)

--- a/FrequencyToggle_Classic.svelte
+++ b/FrequencyToggle_Classic.svelte
@@ -1,0 +1,347 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  
+  export let frequency: string = 'daily';
+  export let userTier: string = 'free';
+  export let disabled: boolean = false;
+  export let email: string = '';
+  export let docketNumber: string = '';
+  
+  const dispatch = createEventDispatcher<{change: {frequency: string}}>();
+  
+  let isLoading: boolean = false;
+  let errorMessage: string = '';
+  
+  $: isImmediate = frequency === 'immediate';
+  $: canUseImmediate = userTier === 'pro' || userTier === 'trial';
+  $: isImmediateDisabled = !canUseImmediate && !isImmediate;
+  
+  async function handleSelection(newFrequency: string) {
+    if (disabled || isLoading || frequency === newFrequency) return;
+    
+    // Check if user can switch to immediate
+    if (newFrequency === 'immediate' && !canUseImmediate) {
+      errorMessage = 'Upgrade to Pro for immediate notifications';
+      setTimeout(() => errorMessage = '', 3000);
+      return;
+    }
+    
+    errorMessage = '';
+    
+    try {
+      isLoading = true;
+      
+      const response = await fetch('/api/subscriptions/frequency', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          docket_number: docketNumber,
+          frequency: newFrequency
+        })
+      });
+      
+      const result = await response.json();
+      
+      if (response.ok) {
+        frequency = newFrequency;
+        dispatch('change', { frequency: newFrequency });
+      } else {
+        errorMessage = result.error?.includes('Pro subscription') 
+          ? 'Upgrade to Pro for immediate notifications'
+          : 'Please try again later';
+        setTimeout(() => errorMessage = '', 3000);
+      }
+    } catch (error) {
+      errorMessage = 'Please check connection and try again';
+      setTimeout(() => errorMessage = '', 3000);
+    } finally {
+      isLoading = false;
+    }
+  }
+</script>
+
+<div class="classic-toggle-container">
+  <fieldset class="frequency-fieldset" class:disabled class:loading={isLoading}>
+    <legend class="fieldset-legend">Notification Frequency</legend>
+    
+    <div class="radio-options">
+      <!-- Daily Option -->
+      <label class="radio-option" class:disabled={disabled || isLoading}>
+        <input 
+          type="radio" 
+          name="frequency"
+          value="daily"
+          checked={!isImmediate}
+          disabled={disabled || isLoading}
+          on:change={() => handleSelection('daily')}
+        />
+        <div class="radio-display">
+          <div class="radio-circle" class:checked={!isImmediate}>
+            {#if !isImmediate}
+              <div class="radio-dot"></div>
+            {/if}
+          </div>
+          <div class="radio-content">
+            <div class="radio-title">Daily Digest</div>
+            <div class="radio-description">Delivered each morning with overnight filings</div>
+          </div>
+        </div>
+      </label>
+      
+      <!-- Immediate Option -->
+      <label 
+        class="radio-option" 
+        class:disabled={disabled || isLoading || isImmediateDisabled}
+        class:pro-required={isImmediateDisabled}
+      >
+        <input 
+          type="radio" 
+          name="frequency"
+          value="immediate"
+          checked={isImmediate}
+          disabled={disabled || isLoading || isImmediateDisabled}
+          on:change={() => handleSelection('immediate')}
+        />
+        <div class="radio-display">
+          <div class="radio-circle" class:checked={isImmediate}>
+            {#if isImmediate}
+              <div class="radio-dot"></div>
+            {/if}
+          </div>
+          <div class="radio-content">
+            <div class="radio-title">
+              Immediate Alerts
+              {#if isImmediateDisabled}
+                <span class="pro-required-badge">Pro Required</span>
+              {/if}
+            </div>
+            <div class="radio-description">Sent within the hour of filing</div>
+          </div>
+        </div>
+      </label>
+    </div>
+    
+    {#if isLoading}
+      <div class="loading-indicator">
+        <div class="spinner"></div>
+        <span>Updating frequency...</span>
+      </div>
+    {/if}
+  </fieldset>
+  
+  {#if errorMessage}
+    <div class="error-message">
+      ⚠️ {errorMessage}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .classic-toggle-container {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.75rem;
+  }
+  
+  .frequency-fieldset {
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    padding: 16px;
+    margin: 0;
+    background: white;
+    position: relative;
+    min-width: 300px;
+  }
+  
+  .frequency-fieldset.disabled {
+    opacity: 0.6;
+    pointer-events: none;
+  }
+  
+  .fieldset-legend {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #374151;
+    padding: 0 8px;
+    margin-bottom: 8px;
+  }
+  
+  .radio-options {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  
+  .radio-option {
+    display: block;
+    cursor: pointer;
+    transition: all 0.2s ease;
+  }
+  
+  .radio-option.disabled {
+    cursor: not-allowed;
+  }
+  
+  .radio-option.pro-required {
+    opacity: 0.7;
+  }
+  
+  .radio-option input[type="radio"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+  }
+  
+  .radio-display {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    transition: all 0.2s ease;
+  }
+  
+  .radio-option:hover:not(.disabled) .radio-display {
+    background: #f9fafb;
+    border-color: #d1d5db;
+  }
+  
+  .radio-option:not(.disabled):not(.pro-required) input:checked + .radio-display {
+    background: #f0fdf4;
+    border-color: #10b981;
+  }
+  
+  .radio-circle {
+    width: 20px;
+    height: 20px;
+    border: 2px solid #d1d5db;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+    margin-top: 2px;
+  }
+  
+  .radio-circle.checked {
+    border-color: #10b981;
+    background: white;
+  }
+  
+  .radio-dot {
+    width: 8px;
+    height: 8px;
+    background: #10b981;
+    border-radius: 50%;
+    transition: all 0.2s ease;
+  }
+  
+  .radio-content {
+    flex: 1;
+  }
+  
+  .radio-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin-bottom: 4px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  
+  .pro-required-badge {
+    font-size: 0.6rem;
+    font-weight: 700;
+    color: white;
+    background: linear-gradient(135deg, #f59e0b, #d97706);
+    padding: 2px 6px;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  
+  .radio-description {
+    font-size: 0.75rem;
+    color: #6b7280;
+    line-height: 1.4;
+  }
+  
+  .radio-option.disabled .radio-title,
+  .radio-option.disabled .radio-description {
+    color: #9ca3af;
+  }
+  
+  .loading-indicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin-top: 12px;
+    padding: 8px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    color: #64748b;
+  }
+  
+  .spinner {
+    width: 16px;
+    height: 16px;
+    border: 2px solid #e2e8f0;
+    border-top: 2px solid #10b981;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+  }
+  
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+  
+  .error-message {
+    padding: 8px 12px;
+    background: rgba(239, 68, 68, 0.1);
+    color: #dc2626;
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    border-radius: 6px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    white-space: nowrap;
+    align-self: center;
+  }
+  
+  /* Mobile responsive */
+  @media (max-width: 768px) {
+    .frequency-fieldset {
+      min-width: 280px;
+      padding: 12px;
+    }
+    
+    .radio-display {
+      padding: 10px;
+    }
+    
+    .radio-title {
+      font-size: 0.8rem;
+    }
+    
+    .radio-description {
+      font-size: 0.7rem;
+    }
+    
+    .radio-circle {
+      width: 18px;
+      height: 18px;
+    }
+    
+    .radio-dot {
+      width: 6px;
+      height: 6px;
+    }
+  }
+</style> 

--- a/FrequencyToggle_Comparison.md
+++ b/FrequencyToggle_Comparison.md
@@ -1,0 +1,123 @@
+# Frequency Toggle Design Comparison
+
+## Current Issues Analysis
+
+The existing frequency toggle on the manage dashboard has several UX problems:
+
+1. **Poor Visual Hierarchy**: It's unclear which setting is currently active
+2. **Confusing Color Logic**: Green for Daily, Grey for Hourly doesn't make intuitive sense
+3. **Weak Active State**: The active state doesn't stand out enough
+4. **Size Constraints**: The toggle is quite small and hard to interact with
+
+## Three New Approaches
+
+### 🎨 1. Creative Approach - Animated Pill Toggle
+
+**Concept**: Modern animated toggle with sliding pill background and icons
+
+**Key Features**:
+- **Sliding Animation**: Smooth emerald pill slides between options
+- **Icon Integration**: 📅 for Daily, ⚡ for Immediate  
+- **Hover Effects**: Subtle lift and glow on interaction
+- **Clear Active State**: White text on emerald background for active option
+- **Size**: 180px × 44px (larger, easier to click)
+
+**UX Benefits**:
+- ✅ Immediately clear which option is active (white text on emerald)
+- ✅ Satisfying animation provides feedback
+- ✅ Icons reinforce meaning without language barriers
+- ✅ Larger interaction area improves accessibility
+
+**File**: `FrequencyToggle_Creative.svelte`
+
+---
+
+### 💼 2. Modern SaaS Approach - Card Selection
+
+**Concept**: Side-by-side cards with detailed descriptions and selection indicators
+
+**Key Features**:
+- **Card Layout**: Two distinct cards side by side
+- **Descriptive Text**: "Perfect for most users" / "Real-time notifications"
+- **Pro Badge**: Clear "PRO" indicator on Immediate option when locked
+- **Checkmark Indicators**: Circular indicators with checkmarks
+- **Hover States**: Cards lift with shadow on hover
+- **Size**: 340px × 80px per card
+
+**UX Benefits**:
+- ✅ Self-explanatory with descriptive text
+- ✅ Professional appearance matching SaaS standards
+- ✅ Clear value proposition for each option
+- ✅ Accessible with proper ARIA labels
+
+**File**: `FrequencyToggle_SaaS.svelte`
+
+---
+
+### 🏛️ 3. Classic Approach - Enhanced Radio Buttons
+
+**Concept**: Traditional form fieldset with enhanced radio button styling
+
+**Key Features**:
+- **Fieldset Structure**: Proper semantic HTML with legend
+- **Custom Radio Styling**: Larger, more visible radio buttons
+- **Detailed Descriptions**: Full explanations for each option
+- **Loading Indicator**: Inline feedback during updates
+- **Traditional Feel**: Familiar interaction pattern
+- **Size**: 300px minimum width, variable height
+
+**UX Benefits**:
+- ✅ Familiar interaction pattern (universally understood)
+- ✅ Excellent accessibility with native form elements
+- ✅ Clear semantic structure for screen readers
+- ✅ Detailed explanations reduce confusion
+
+**File**: `FrequencyToggle_Classic.svelte`
+
+---
+
+## Comparison Matrix
+
+| Aspect | Creative | SaaS | Classic |
+|--------|----------|------|---------|
+| **Visual Impact** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐ |
+| **Clarity** | ⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ |
+| **Accessibility** | ⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ |
+| **Animation** | ⭐⭐⭐⭐⭐ | ⭐⭐ | ⭐ |
+| **Space Efficiency** | ⭐⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ |
+| **Brand Consistency** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ |
+
+## Technical Implementation
+
+All three approaches:
+- ✅ Use the same API endpoints and error handling
+- ✅ Support the same props (frequency, userTier, disabled, etc.)
+- ✅ Emit the same events for parent component integration
+- ✅ Include loading states and error messages
+- ✅ Are fully responsive for mobile devices
+- ✅ Handle Pro tier restrictions appropriately
+
+## Recommendations
+
+### For SimpleDCC, I recommend the **🎨 Creative Approach** because:
+
+1. **Best Balance**: Combines visual appeal with functional clarity
+2. **Modern Feel**: Matches the sleek, professional SimpleDCC brand
+3. **User Feedback**: The animation provides satisfying interaction feedback
+4. **Compact**: Takes less vertical space on the dashboard
+5. **Brand Colors**: Uses the emerald theme consistently
+
+### Alternative Recommendations:
+
+- **Choose SaaS** if you want maximum clarity and descriptive text
+- **Choose Classic** if accessibility is the top priority or users prefer traditional interfaces
+
+## Implementation Notes
+
+To replace the current toggle:
+
+1. Copy the chosen component file to `src/lib/components/`
+2. Update the import in `src/routes/manage/+page.svelte`
+3. The component interface is identical, so no other changes needed
+
+The emerald color scheme (`#10b981`) is consistent across all approaches and matches your existing design system constants. 

--- a/FrequencyToggle_Creative.svelte
+++ b/FrequencyToggle_Creative.svelte
@@ -1,0 +1,267 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  
+  export let frequency: string = 'daily';
+  export let userTier: string = 'free';
+  export let disabled: boolean = false;
+  export let email: string = '';
+  export let docketNumber: string = '';
+  
+  const dispatch = createEventDispatcher<{change: {frequency: string}}>();
+  
+  let isLoading: boolean = false;
+  let errorMessage: string = '';
+  
+  $: isImmediate = frequency === 'immediate';
+  $: canUseImmediate = userTier === 'pro' || userTier === 'trial';
+  $: isImmediateDisabled = !canUseImmediate && !isImmediate;
+  
+  async function handleToggle(newFrequency: string) {
+    if (disabled || isLoading || frequency === newFrequency) return;
+    
+    // Check if user can switch to immediate
+    if (newFrequency === 'immediate' && !canUseImmediate) {
+      errorMessage = 'Upgrade to Pro for immediate notifications';
+      setTimeout(() => errorMessage = '', 3000);
+      return;
+    }
+    
+    errorMessage = '';
+    
+    try {
+      isLoading = true;
+      
+      const response = await fetch('/api/subscriptions/frequency', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          docket_number: docketNumber,
+          frequency: newFrequency
+        })
+      });
+      
+      const result = await response.json();
+      
+      if (response.ok) {
+        frequency = newFrequency;
+        dispatch('change', { frequency: newFrequency });
+      } else {
+        errorMessage = result.error?.includes('Pro subscription') 
+          ? 'Upgrade to Pro for immediate notifications'
+          : 'Please try again later';
+        setTimeout(() => errorMessage = '', 3000);
+      }
+    } catch (error) {
+      errorMessage = 'Please check connection and try again';
+      setTimeout(() => errorMessage = '', 3000);
+    } finally {
+      isLoading = false;
+    }
+  }
+</script>
+
+<div class="creative-toggle-container">
+  <div class="toggle-wrapper" class:disabled class:loading={isLoading}>
+    <!-- Background track -->
+    <div class="toggle-track">
+      <!-- Sliding pill background -->
+      <div class="sliding-pill" class:immediate={isImmediate}></div>
+      
+      <!-- Option buttons -->
+      <button 
+        class="option-btn daily" 
+        class:active={!isImmediate}
+        disabled={disabled || isLoading}
+        on:click={() => handleToggle('daily')}
+      >
+        <span class="option-icon">📅</span>
+        <span class="option-text">Daily</span>
+      </button>
+      
+      <button 
+        class="option-btn immediate" 
+        class:active={isImmediate}
+        class:disabled={isImmediateDisabled}
+        disabled={disabled || isLoading || isImmediateDisabled}
+        on:click={() => handleToggle('immediate')}
+      >
+        <span class="option-icon">⚡</span>
+        <span class="option-text">Immediate</span>
+      </button>
+    </div>
+    
+    {#if isLoading}
+      <div class="loading-overlay">
+        <div class="spinner"></div>
+      </div>
+    {/if}
+  </div>
+  
+  {#if errorMessage}
+    <div class="error-message">
+      ⚠️ {errorMessage}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .creative-toggle-container {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
+  }
+  
+  .toggle-wrapper {
+    position: relative;
+    border-radius: 24px;
+    overflow: hidden;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    transition: all 0.3s ease;
+  }
+  
+  .toggle-wrapper:hover:not(.disabled) {
+    box-shadow: 0 4px 12px rgba(16, 185, 129, 0.15);
+    transform: translateY(-1px);
+  }
+  
+  .toggle-wrapper.disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  
+  .toggle-track {
+    position: relative;
+    display: flex;
+    background: #f1f5f9;
+    border: 2px solid #e2e8f0;
+    border-radius: 24px;
+    padding: 3px;
+    width: 180px;
+    height: 44px;
+  }
+  
+  .sliding-pill {
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 85px;
+    height: 34px;
+    background: linear-gradient(135deg, #10b981, #059669);
+    border-radius: 20px;
+    box-shadow: 0 2px 6px rgba(16, 185, 129, 0.3);
+    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    z-index: 1;
+  }
+  
+  .sliding-pill.immediate {
+    transform: translateX(86px);
+  }
+  
+  .option-btn {
+    position: relative;
+    z-index: 2;
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    background: none;
+    border: none;
+    border-radius: 20px;
+    padding: 8px 12px;
+    font-family: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #64748b;
+    cursor: pointer;
+    transition: all 0.3s ease;
+  }
+  
+  .option-btn:disabled {
+    cursor: not-allowed;
+  }
+  
+  .option-btn.active {
+    color: white;
+    font-weight: 600;
+  }
+  
+  .option-btn.disabled {
+    opacity: 0.5;
+  }
+  
+  .option-icon {
+    font-size: 1rem;
+    transition: transform 0.3s ease;
+  }
+  
+  .option-btn:hover:not(:disabled) .option-icon {
+    transform: scale(1.1);
+  }
+  
+  .option-text {
+    font-size: 0.875rem;
+    white-space: nowrap;
+  }
+  
+  .loading-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(255, 255, 255, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 24px;
+    z-index: 3;
+  }
+  
+  .spinner {
+    width: 20px;
+    height: 20px;
+    border: 2px solid #e2e8f0;
+    border-top: 2px solid #10b981;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+  }
+  
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+  
+  .error-message {
+    padding: 6px 12px;
+    background: rgba(239, 68, 68, 0.1);
+    color: #dc2626;
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    border-radius: 8px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+  
+  /* Mobile responsive */
+  @media (max-width: 768px) {
+    .toggle-track {
+      width: 160px;
+      height: 40px;
+    }
+    
+    .sliding-pill {
+      width: 75px;
+      height: 30px;
+    }
+    
+    .sliding-pill.immediate {
+      transform: translateX(76px);
+    }
+    
+    .option-text {
+      font-size: 0.8rem;
+    }
+  }
+</style> 

--- a/FrequencyToggle_SaaS.svelte
+++ b/FrequencyToggle_SaaS.svelte
@@ -1,0 +1,308 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  
+  export let frequency: string = 'daily';
+  export let userTier: string = 'free';
+  export let disabled: boolean = false;
+  export let email: string = '';
+  export let docketNumber: string = '';
+  
+  const dispatch = createEventDispatcher<{change: {frequency: string}}>();
+  
+  let isLoading: boolean = false;
+  let errorMessage: string = '';
+  
+  $: isImmediate = frequency === 'immediate';
+  $: canUseImmediate = userTier === 'pro' || userTier === 'trial';
+  $: isImmediateDisabled = !canUseImmediate && !isImmediate;
+  
+  async function handleSelection(newFrequency: string) {
+    if (disabled || isLoading || frequency === newFrequency) return;
+    
+    // Check if user can switch to immediate
+    if (newFrequency === 'immediate' && !canUseImmediate) {
+      errorMessage = 'Upgrade to Pro for immediate notifications';
+      setTimeout(() => errorMessage = '', 3000);
+      return;
+    }
+    
+    errorMessage = '';
+    
+    try {
+      isLoading = true;
+      
+      const response = await fetch('/api/subscriptions/frequency', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          docket_number: docketNumber,
+          frequency: newFrequency
+        })
+      });
+      
+      const result = await response.json();
+      
+      if (response.ok) {
+        frequency = newFrequency;
+        dispatch('change', { frequency: newFrequency });
+      } else {
+        errorMessage = result.error?.includes('Pro subscription') 
+          ? 'Upgrade to Pro for immediate notifications'
+          : 'Please try again later';
+        setTimeout(() => errorMessage = '', 3000);
+      }
+    } catch (error) {
+      errorMessage = 'Please check connection and try again';
+      setTimeout(() => errorMessage = '', 3000);
+    } finally {
+      isLoading = false;
+    }
+  }
+</script>
+
+<div class="saas-toggle-container">
+  <div class="frequency-cards" class:disabled class:loading={isLoading}>
+    <!-- Daily Card -->
+    <button 
+      class="frequency-card daily"
+      class:active={!isImmediate}
+      disabled={disabled || isLoading}
+      on:click={() => handleSelection('daily')}
+    >
+      <div class="card-icon">📅</div>
+      <div class="card-content">
+        <div class="card-title">Daily Digest</div>
+        <div class="card-description">Perfect for most users</div>
+      </div>
+      <div class="card-indicator" class:visible={!isImmediate}>
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <path d="M13.5 4.5L6 12L2.5 8.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </div>
+    </button>
+    
+    <!-- Immediate Card -->
+    <button 
+      class="frequency-card immediate"
+      class:active={isImmediate}
+      class:disabled={isImmediateDisabled}
+      disabled={disabled || isLoading || isImmediateDisabled}
+      on:click={() => handleSelection('immediate')}
+    >
+      <div class="card-icon">⚡</div>
+      <div class="card-content">
+        <div class="card-title">
+          Immediate Alerts
+          {#if isImmediateDisabled}
+            <span class="pro-badge">PRO</span>
+          {/if}
+        </div>
+        <div class="card-description">Real-time notifications</div>
+      </div>
+      <div class="card-indicator" class:visible={isImmediate}>
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <path d="M13.5 4.5L6 12L2.5 8.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </div>
+    </button>
+    
+    {#if isLoading}
+      <div class="loading-overlay">
+        <div class="spinner"></div>
+      </div>
+    {/if}
+  </div>
+  
+  {#if errorMessage}
+    <div class="error-message">
+      ⚠️ {errorMessage}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .saas-toggle-container {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.75rem;
+  }
+  
+  .frequency-cards {
+    position: relative;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    width: 340px;
+  }
+  
+  .frequency-cards.disabled {
+    opacity: 0.6;
+    pointer-events: none;
+  }
+  
+  .frequency-card {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px;
+    background: white;
+    border: 2px solid #e2e8f0;
+    border-radius: 12px;
+    cursor: pointer;
+    transition: all 0.25s ease;
+    font-family: inherit;
+    text-align: left;
+    min-height: 80px;
+  }
+  
+  .frequency-card:hover:not(:disabled):not(.disabled) {
+    border-color: #cbd5e1;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    transform: translateY(-1px);
+  }
+  
+  .frequency-card.active {
+    border-color: #10b981;
+    background: linear-gradient(135deg, #f0fdf4 0%, #ecfdf5 100%);
+    box-shadow: 0 4px 16px rgba(16, 185, 129, 0.15);
+  }
+  
+  .frequency-card.disabled {
+    cursor: not-allowed;
+    background: #f8fafc;
+    border-color: #e2e8f0;
+  }
+  
+  .card-icon {
+    font-size: 1.5rem;
+    flex-shrink: 0;
+    transition: transform 0.25s ease;
+  }
+  
+  .frequency-card:hover:not(:disabled) .card-icon {
+    transform: scale(1.1);
+  }
+  
+  .card-content {
+    flex: 1;
+    min-width: 0;
+  }
+  
+  .card-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin-bottom: 2px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  
+  .pro-badge {
+    font-size: 0.6rem;
+    font-weight: 700;
+    color: white;
+    background: linear-gradient(135deg, #f59e0b, #d97706);
+    padding: 2px 6px;
+    border-radius: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  
+  .card-description {
+    font-size: 0.75rem;
+    color: #64748b;
+    line-height: 1.3;
+  }
+  
+  .frequency-card.disabled .card-title,
+  .frequency-card.disabled .card-description {
+    color: #9ca3af;
+  }
+  
+  .card-indicator {
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #e2e8f0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: transparent;
+    transition: all 0.25s ease;
+  }
+  
+  .card-indicator.visible {
+    background: #10b981;
+    color: white;
+  }
+  
+  .loading-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(255, 255, 255, 0.9);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 12px;
+    z-index: 1;
+  }
+  
+  .spinner {
+    width: 24px;
+    height: 24px;
+    border: 2px solid #e2e8f0;
+    border-top: 2px solid #10b981;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+  }
+  
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+  
+  .error-message {
+    padding: 8px 12px;
+    background: rgba(239, 68, 68, 0.1);
+    color: #dc2626;
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    border-radius: 8px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    white-space: nowrap;
+    align-self: center;
+  }
+  
+  /* Mobile responsive */
+  @media (max-width: 768px) {
+    .frequency-cards {
+      width: 100%;
+      max-width: 320px;
+      gap: 8px;
+    }
+    
+    .frequency-card {
+      padding: 12px;
+      min-height: 70px;
+    }
+    
+    .card-icon {
+      font-size: 1.25rem;
+    }
+    
+    .card-title {
+      font-size: 0.8rem;
+    }
+    
+    .card-description {
+      font-size: 0.7rem;
+    }
+  }
+</style> 

--- a/src/lib/components/FrequencyToggle_Classic.svelte
+++ b/src/lib/components/FrequencyToggle_Classic.svelte
@@ -1,0 +1,328 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  
+  export let frequency: string = 'daily';
+  export let userTier: string = 'free';
+  export let disabled: boolean = false;
+  export let email: string = '';
+  export let docketNumber: string = '';
+  
+  const dispatch = createEventDispatcher<{change: {frequency: string}}>();
+  
+  let isLoading: boolean = false;
+  let errorMessage: string = '';
+  
+  $: isImmediate = frequency === 'immediate';
+  $: canUseImmediate = userTier === 'pro' || userTier === 'trial';
+  $: isImmediateDisabled = !canUseImmediate && !isImmediate;
+  
+  async function handleSelection(newFrequency: string) {
+    if (disabled || isLoading || frequency === newFrequency) return;
+    
+    // Check if user can switch to immediate
+    if (newFrequency === 'immediate' && !canUseImmediate) {
+      errorMessage = 'Immediate notifications require a Pro subscription';
+      return;
+    }
+    
+    isLoading = true;
+    errorMessage = '';
+    
+    try {
+      const response = await fetch('/api/update-frequency', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          docketNumber,
+          frequency: newFrequency
+        })
+      });
+      
+      if (response.ok) {
+        frequency = newFrequency;
+        dispatch('change', { frequency: newFrequency });
+      } else {
+        const error = await response.json();
+        errorMessage = error.message || 'Failed to update frequency';
+      }
+    } catch (error) {
+      errorMessage = 'Network error. Please try again.';
+    } finally {
+      isLoading = false;
+    }
+  }
+</script>
+
+<div class="frequency-toggle classic">
+  <fieldset class="radio-group" class:disabled>
+    <legend class="sr-only">Notification Frequency</legend>
+    
+    <div class="radio-options">
+      <label class="radio-option" class:selected={!isImmediate}>
+        <input 
+          type="radio" 
+          name="frequency" 
+          value="daily" 
+          checked={!isImmediate}
+          disabled={disabled || isLoading}
+          on:change={() => handleSelection('daily')}
+        />
+        <div class="radio-custom">
+          <div class="radio-circle"></div>
+        </div>
+        <div class="option-content">
+          <div class="option-header">
+            <span class="icon">📅</span>
+            <h3>Daily Digest</h3>
+          </div>
+          <p class="description">Delivered each morning at 9 AM</p>
+          <p class="details">Perfect for users who prefer to review all updates at once</p>
+        </div>
+      </label>
+      
+      <label class="radio-option" class:selected={isImmediate} class:disabled={isImmediateDisabled}>
+        <input 
+          type="radio" 
+          name="frequency" 
+          value="immediate" 
+          checked={isImmediate}
+          disabled={disabled || isLoading || isImmediateDisabled}
+          on:change={() => handleSelection('immediate')}
+        />
+        <div class="radio-custom">
+          <div class="radio-circle"></div>
+        </div>
+        <div class="option-content">
+          <div class="option-header">
+            <span class="icon">⚡</span>
+            <h3>Immediate Alerts</h3>
+            {#if isImmediateDisabled}
+              <span class="pro-badge">PRO</span>
+            {/if}
+          </div>
+          <p class="description">Sent within the hour of new filings</p>
+          <p class="details">Real-time notifications for time-sensitive updates</p>
+        </div>
+      </label>
+    </div>
+  </fieldset>
+  
+  {#if errorMessage}
+    <div class="error-message">{errorMessage}</div>
+  {/if}
+  
+  {#if isImmediateDisabled}
+    <div class="upgrade-notice">
+      <span class="icon">🔒</span>
+      Upgrade to Pro for immediate notifications
+    </div>
+  {/if}
+</div>
+
+<style>
+  .frequency-toggle.classic {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    width: 100%;
+    max-width: 500px;
+  }
+  
+  .radio-group {
+    border: none;
+    padding: 0;
+    margin: 0;
+    width: 100%;
+  }
+  
+  .radio-group.disabled {
+    opacity: 0.6;
+    pointer-events: none;
+  }
+  
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  
+  .radio-options {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  
+  .radio-option {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 1.5rem;
+    border: 2px solid #e2e8f0;
+    border-radius: 12px;
+    cursor: pointer;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    background: white;
+  }
+  
+  .radio-option:hover:not(.disabled) {
+    border-color: #10b981;
+    background: #f8fafc;
+  }
+  
+  .radio-option.selected {
+    border-color: #10b981;
+    background: linear-gradient(135deg, #f0fdf4, #ecfdf5);
+    box-shadow: 0 4px 20px rgba(16, 185, 129, 0.15);
+  }
+  
+  .radio-option.disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+  
+  .radio-option input[type="radio"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+  }
+  
+  .radio-custom {
+    position: relative;
+    width: 20px;
+    height: 20px;
+    border: 2px solid #cbd5e1;
+    border-radius: 50%;
+    background: white;
+    flex-shrink: 0;
+    margin-top: 0.25rem;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  
+  .radio-option:hover .radio-custom {
+    border-color: #10b981;
+  }
+  
+  .radio-option.selected .radio-custom {
+    border-color: #10b981;
+    background: #10b981;
+  }
+  
+  .radio-circle {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 8px;
+    height: 8px;
+    background: white;
+    border-radius: 50%;
+    transform: translate(-50%, -50%) scale(0);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  
+  .radio-option.selected .radio-circle {
+    transform: translate(-50%, -50%) scale(1);
+  }
+  
+  .option-content {
+    flex: 1;
+  }
+  
+  .option-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+  }
+  
+  .option-header h3 {
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: #1e293b;
+    margin: 0;
+    flex: 1;
+  }
+  
+  .icon {
+    font-size: 1.25rem;
+  }
+  
+  .pro-badge {
+    background: linear-gradient(135deg, #10b981, #059669);
+    color: white;
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 0.25rem 0.5rem;
+    border-radius: 6px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  
+  .description {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #374151;
+    margin: 0 0 0.25rem 0;
+  }
+  
+  .details {
+    font-size: 0.875rem;
+    color: #64748b;
+    margin: 0;
+    line-height: 1.4;
+  }
+  
+  .error-message {
+    color: #dc2626;
+    font-size: 0.875rem;
+    text-align: center;
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    width: 100%;
+  }
+  
+  .upgrade-notice {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: #f59e0b;
+    font-size: 0.875rem;
+    background: #fffbeb;
+    border: 1px solid #fed7aa;
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    width: 100%;
+  }
+  
+  .upgrade-notice .icon {
+    font-size: 1rem;
+  }
+  
+  /* Mobile responsive */
+  @media (max-width: 640px) {
+    .radio-option {
+      padding: 1.25rem;
+    }
+    
+    .option-header h3 {
+      font-size: 1rem;
+    }
+    
+    .description {
+      font-size: 0.9rem;
+    }
+    
+    .details {
+      font-size: 0.8rem;
+    }
+  }
+</style> 

--- a/src/lib/components/FrequencyToggle_Creative.svelte
+++ b/src/lib/components/FrequencyToggle_Creative.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  
+  export let frequency: string = 'daily';
+  export let userTier: string = 'free';
+  export let disabled: boolean = false;
+  export let email: string = '';
+  export let docketNumber: string = '';
+  
+  const dispatch = createEventDispatcher<{change: {frequency: string}}>();
+  
+  let isLoading: boolean = false;
+  let errorMessage: string = '';
+  
+  $: isImmediate = frequency === 'immediate';
+  $: canUseImmediate = userTier === 'pro' || userTier === 'trial';
+  $: isImmediateDisabled = !canUseImmediate && !isImmediate;
+  
+  function handleToggle(newFrequency: string) {
+    if (disabled || isLoading || frequency === newFrequency) return;
+    
+    // Check if user can switch to immediate
+    if (newFrequency === 'immediate' && !canUseImmediate) {
+      errorMessage = 'Immediate notifications require a Pro subscription';
+      return;
+    }
+    
+    // Demo mode - just update the state
+    frequency = newFrequency;
+    errorMessage = '';
+    dispatch('change', { frequency: newFrequency });
+  }
+</script>
+
+<div class="frequency-toggle creative">
+  <div class="toggle-container" class:disabled>
+    <button 
+      class="toggle-option daily" 
+      class:active={!isImmediate}
+      class:disabled={disabled || isLoading}
+      on:click={() => handleToggle('daily')}
+      disabled={disabled || isLoading}
+    >
+      <span class="icon">📅</span>
+      <span class="text">Daily</span>
+    </button>
+    
+    <button 
+      class="toggle-option immediate" 
+      class:active={isImmediate}
+      class:disabled={disabled || isLoading || isImmediateDisabled}
+      on:click={() => handleToggle('immediate')}
+      disabled={disabled || isLoading || isImmediateDisabled}
+    >
+      <span class="icon">⚡</span>
+      <span class="text">Immediate</span>
+    </button>
+    
+    <!-- Sliding background pill -->
+    <div class="sliding-pill" class:immediate={isImmediate}></div>
+  </div>
+  
+  {#if errorMessage}
+    <div class="error-message">{errorMessage}</div>
+  {/if}
+  
+  {#if isImmediateDisabled}
+    <div class="upgrade-notice">
+      <span class="icon">🔒</span>
+      Pro subscription required for immediate notifications
+    </div>
+  {/if}
+</div>
+
+<style>
+  .frequency-toggle.creative {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  
+  .toggle-container {
+    position: relative;
+    display: flex;
+    background: #f1f5f9;
+    border-radius: 22px;
+    padding: 4px;
+    width: 200px;
+    height: 48px;
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+  }
+  
+  .toggle-container.disabled {
+    opacity: 0.6;
+    pointer-events: none;
+  }
+  
+  .toggle-option {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    flex: 1;
+    border: none;
+    background: transparent;
+    border-radius: 20px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #64748b;
+    cursor: pointer;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    padding: 0.5rem 1rem;
+  }
+  
+  .toggle-option:hover:not(.disabled) {
+    color: #1e293b;
+    transform: translateY(-1px);
+  }
+  
+  .toggle-option.active {
+    color: white;
+    font-weight: 700;
+  }
+  
+  .toggle-option.disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+  
+  .icon {
+    font-size: 1.1rem;
+  }
+  
+  .sliding-pill {
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    width: calc(50% - 4px);
+    height: calc(100% - 8px);
+    background: linear-gradient(135deg, #10b981, #059669);
+    border-radius: 20px;
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: 0 2px 8px rgba(16, 185, 129, 0.3);
+    z-index: 1;
+  }
+  
+  .sliding-pill.immediate {
+    transform: translateX(100%);
+  }
+  
+  .error-message {
+    color: #dc2626;
+    font-size: 0.875rem;
+    text-align: center;
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    border-radius: 8px;
+    padding: 0.5rem 1rem;
+    max-width: 300px;
+  }
+  
+  .upgrade-notice {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: #f59e0b;
+    font-size: 0.875rem;
+    background: #fffbeb;
+    border: 1px solid #fed7aa;
+    border-radius: 8px;
+    padding: 0.5rem 1rem;
+    max-width: 300px;
+  }
+  
+  .upgrade-notice .icon {
+    font-size: 1rem;
+  }
+</style> 

--- a/src/lib/components/FrequencyToggle_SaaS.svelte
+++ b/src/lib/components/FrequencyToggle_SaaS.svelte
@@ -1,0 +1,267 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  
+  export let frequency: string = 'daily';
+  export let userTier: string = 'free';
+  export let disabled: boolean = false;
+  export let email: string = '';
+  export let docketNumber: string = '';
+  
+  const dispatch = createEventDispatcher<{change: {frequency: string}}>();
+  
+  let isLoading: boolean = false;
+  let errorMessage: string = '';
+  
+  $: isImmediate = frequency === 'immediate';
+  $: canUseImmediate = userTier === 'pro' || userTier === 'trial';
+  $: isImmediateDisabled = !canUseImmediate && !isImmediate;
+  
+  async function handleSelection(newFrequency: string) {
+    if (disabled || isLoading || frequency === newFrequency) return;
+    
+    // Check if user can switch to immediate
+    if (newFrequency === 'immediate' && !canUseImmediate) {
+      errorMessage = 'Immediate notifications require a Pro subscription';
+      return;
+    }
+    
+    isLoading = true;
+    errorMessage = '';
+    
+    try {
+      const response = await fetch('/api/update-frequency', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          docketNumber,
+          frequency: newFrequency
+        })
+      });
+      
+      if (response.ok) {
+        frequency = newFrequency;
+        dispatch('change', { frequency: newFrequency });
+      } else {
+        const error = await response.json();
+        errorMessage = error.message || 'Failed to update frequency';
+      }
+    } catch (error) {
+      errorMessage = 'Network error. Please try again.';
+    } finally {
+      isLoading = false;
+    }
+  }
+</script>
+
+<div class="frequency-toggle saas">
+  <div class="selection-grid">
+    <button 
+      class="option-card daily" 
+      class:active={!isImmediate}
+      class:disabled={disabled || isLoading}
+      on:click={() => handleSelection('daily')}
+      disabled={disabled || isLoading}
+    >
+      <div class="card-header">
+        <span class="icon">📅</span>
+        <h3>Daily Digest</h3>
+      </div>
+      <p class="description">Perfect for most users</p>
+      <p class="details">Delivered each morning at 9 AM</p>
+      <div class="active-indicator" class:show={!isImmediate}>
+        <span>✓</span>
+      </div>
+    </button>
+    
+    <button 
+      class="option-card immediate" 
+      class:active={isImmediate}
+      class:disabled={disabled || isLoading || isImmediateDisabled}
+      on:click={() => handleSelection('immediate')}
+      disabled={disabled || isLoading || isImmediateDisabled}
+    >
+      <div class="card-header">
+        <span class="icon">⚡</span>
+        <h3>Immediate Alerts</h3>
+        {#if isImmediateDisabled}
+          <span class="pro-badge">PRO</span>
+        {/if}
+      </div>
+      <p class="description">Real-time notifications</p>
+      <p class="details">Sent within the hour of new filings</p>
+      <div class="active-indicator" class:show={isImmediate}>
+        <span>✓</span>
+      </div>
+    </button>
+  </div>
+  
+  {#if errorMessage}
+    <div class="error-message">{errorMessage}</div>
+  {/if}
+  
+  {#if isImmediateDisabled}
+    <div class="upgrade-notice">
+      <span class="icon">🔒</span>
+      Upgrade to Pro for immediate notifications
+    </div>
+  {/if}
+</div>
+
+<style>
+  .frequency-toggle.saas {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+  }
+  
+  .selection-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    width: 100%;
+    max-width: 500px;
+  }
+  
+  .option-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    background: white;
+    border: 2px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 1.5rem;
+    cursor: pointer;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    text-align: left;
+    min-height: 140px;
+  }
+  
+  .option-card:hover:not(.disabled) {
+    border-color: #10b981;
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(16, 185, 129, 0.15);
+  }
+  
+  .option-card.active {
+    border-color: #10b981;
+    background: linear-gradient(135deg, #f0fdf4, #ecfdf5);
+    box-shadow: 0 4px 20px rgba(16, 185, 129, 0.2);
+  }
+  
+  .option-card.disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+  
+  .card-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+    width: 100%;
+  }
+  
+  .card-header h3 {
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: #1e293b;
+    margin: 0;
+    flex: 1;
+  }
+  
+  .icon {
+    font-size: 1.5rem;
+  }
+  
+  .pro-badge {
+    background: linear-gradient(135deg, #10b981, #059669);
+    color: white;
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 0.25rem 0.5rem;
+    border-radius: 6px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  
+  .description {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #374151;
+    margin: 0 0 0.5rem 0;
+  }
+  
+  .details {
+    font-size: 0.875rem;
+    color: #64748b;
+    margin: 0;
+    line-height: 1.4;
+  }
+  
+  .active-indicator {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    width: 24px;
+    height: 24px;
+    background: #10b981;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-size: 0.875rem;
+    font-weight: 700;
+    opacity: 0;
+    transform: scale(0);
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  
+  .active-indicator.show {
+    opacity: 1;
+    transform: scale(1);
+  }
+  
+  .error-message {
+    color: #dc2626;
+    font-size: 0.875rem;
+    text-align: center;
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    max-width: 500px;
+  }
+  
+  .upgrade-notice {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: #f59e0b;
+    font-size: 0.875rem;
+    background: #fffbeb;
+    border: 1px solid #fed7aa;
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    max-width: 500px;
+  }
+  
+  .upgrade-notice .icon {
+    font-size: 1rem;
+  }
+  
+  /* Mobile responsive */
+  @media (max-width: 640px) {
+    .selection-grid {
+      grid-template-columns: 1fr;
+    }
+    
+    .option-card {
+      min-height: 120px;
+      padding: 1.25rem;
+    }
+  }
+</style> 

--- a/src/routes/demo-frequency-toggles/+page.svelte
+++ b/src/routes/demo-frequency-toggles/+page.svelte
@@ -1,0 +1,461 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  
+  // Import our three toggle components (we'll create them in the components folder)
+  import FrequencyToggleCreative from '$lib/components/FrequencyToggle_Creative.svelte';
+  import FrequencyToggleSaaS from '$lib/components/FrequencyToggle_SaaS.svelte';
+  import FrequencyToggleClassic from '$lib/components/FrequencyToggle_Classic.svelte';
+  
+  // State for each toggle
+  let creativeFreq = 'daily';
+  let saasFreq = 'immediate';
+  let classicFreq = 'daily';
+  
+  // Different user tiers for testing
+  let userTier = 'pro'; // Change to 'free' to test restrictions
+  
+  function handleCreativeChange(event) {
+    creativeFreq = event.detail.frequency;
+    console.log('Creative toggle changed to:', creativeFreq);
+  }
+  
+  function handleSaasChange(event) {
+    saasFreq = event.detail.frequency;
+    console.log('SaaS toggle changed to:', saasFreq);
+  }
+  
+  function handleClassicChange(event) {
+    classicFreq = event.detail.frequency;
+    console.log('Classic toggle changed to:', classicFreq);
+  }
+  
+  function toggleUserTier() {
+    userTier = userTier === 'free' ? 'pro' : 'free';
+  }
+</script>
+
+<svelte:head>
+  <title>Frequency Toggle Design Comparison - SimpleDCC</title>
+</svelte:head>
+
+<div class="demo-page">
+  <div class="demo-header">
+    <h1>🎛️ Frequency Toggle Design Comparison</h1>
+    <p class="subtitle">Three different approaches to solve the UX issues with the current toggle</p>
+    
+    <div class="controls">
+      <button class="tier-toggle" on:click={toggleUserTier}>
+        Current User Tier: <strong>{userTier.toUpperCase()}</strong>
+        (Click to switch)
+      </button>
+    </div>
+  </div>
+  
+  <div class="comparison-grid">
+    <!-- Creative Approach -->
+    <div class="approach-card">
+      <div class="approach-header">
+        <h2>🎨 Creative Approach</h2>
+        <div class="badges">
+          <span class="badge recommended">Recommended</span>
+          <span class="badge animated">Animated</span>
+        </div>
+      </div>
+      
+      <div class="approach-description">
+        <p><strong>Animated pill toggle</strong> with sliding emerald background</p>
+        <ul>
+          <li>✅ Clear active state (white text on emerald)</li>
+          <li>✅ Smooth animations provide feedback</li>
+          <li>✅ Icons reinforce meaning</li>
+          <li>✅ Compact and modern</li>
+        </ul>
+      </div>
+      
+      <div class="demo-area">
+        <div class="demo-label">Current: {creativeFreq}</div>
+        <FrequencyToggleCreative 
+          frequency={creativeFreq}
+          {userTier}
+          email="demo@example.com"
+          docketNumber="11-42"
+          on:change={handleCreativeChange}
+        />
+      </div>
+    </div>
+    
+    <!-- SaaS Approach -->
+    <div class="approach-card">
+      <div class="approach-header">
+        <h2>💼 Modern SaaS Approach</h2>
+        <div class="badges">
+          <span class="badge descriptive">Descriptive</span>
+          <span class="badge professional">Professional</span>
+        </div>
+      </div>
+      
+      <div class="approach-description">
+        <p><strong>Side-by-side cards</strong> with detailed descriptions</p>
+        <ul>
+          <li>✅ Self-explanatory with descriptive text</li>
+          <li>✅ Professional SaaS appearance</li>
+          <li>✅ Clear value proposition</li>
+          <li>✅ Excellent accessibility</li>
+        </ul>
+      </div>
+      
+      <div class="demo-area">
+        <div class="demo-label">Current: {saasFreq}</div>
+        <FrequencyToggleSaaS 
+          frequency={saasFreq}
+          {userTier}
+          email="demo@example.com"
+          docketNumber="11-42"
+          on:change={handleSaasChange}
+        />
+      </div>
+    </div>
+    
+    <!-- Classic Approach -->
+    <div class="approach-card">
+      <div class="approach-header">
+        <h2>🏛️ Classic Approach</h2>
+        <div class="badges">
+          <span class="badge accessible">Accessible</span>
+          <span class="badge familiar">Familiar</span>
+        </div>
+      </div>
+      
+      <div class="approach-description">
+        <p><strong>Enhanced radio buttons</strong> in semantic fieldset</p>
+        <ul>
+          <li>✅ Familiar interaction pattern</li>
+          <li>✅ Maximum accessibility</li>
+          <li>✅ Clear semantic structure</li>
+          <li>✅ Detailed explanations</li>
+        </ul>
+      </div>
+      
+      <div class="demo-area">
+        <div class="demo-label">Current: {classicFreq}</div>
+        <FrequencyToggleClassic 
+          frequency={classicFreq}
+          {userTier}
+          email="demo@example.com"
+          docketNumber="11-42"
+          on:change={handleClassicChange}
+        />
+      </div>
+    </div>
+  </div>
+  
+  <!-- Current Issues Section -->
+  <div class="issues-section">
+    <h2>🚨 Issues with Current Toggle</h2>
+    <div class="issues-grid">
+      <div class="issue-card">
+        <h3>Poor Visual Hierarchy</h3>
+        <p>Unclear which setting is currently active</p>
+      </div>
+      <div class="issue-card">
+        <h3>Confusing Color Logic</h3>
+        <p>Green for Daily, Grey for Hourly doesn't make sense</p>
+      </div>
+      <div class="issue-card">
+        <h3>Small Interaction Area</h3>
+        <p>Toggle is quite small and hard to click</p>
+      </div>
+      <div class="issue-card">
+        <h3>Weak Active State</h3>
+        <p>Active state doesn't stand out enough</p>
+      </div>
+    </div>
+  </div>
+  
+  <!-- Technical Notes -->
+  <div class="tech-notes">
+    <h2>🔧 Technical Implementation</h2>
+    <div class="tech-grid">
+      <div class="tech-card">
+        <h3>API Compatibility</h3>
+        <p>All three use the same API endpoints and props</p>
+      </div>
+      <div class="tech-card">
+        <h3>Drop-in Replacement</h3>
+        <p>Identical component interface for easy swapping</p>
+      </div>
+      <div class="tech-card">
+        <h3>Responsive Design</h3>
+        <p>All approaches work perfectly on mobile</p>
+      </div>
+      <div class="tech-card">
+        <h3>Brand Consistency</h3>
+        <p>Uses SimpleDCC's emerald color scheme</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .demo-page {
+    min-height: 100vh;
+    background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+    padding: 2rem;
+  }
+  
+  .demo-header {
+    text-align: center;
+    margin-bottom: 3rem;
+  }
+  
+  .demo-header h1 {
+    font-size: 2.5rem;
+    font-weight: 800;
+    color: #1e293b;
+    margin-bottom: 0.5rem;
+  }
+  
+  .subtitle {
+    font-size: 1.2rem;
+    color: #64748b;
+    margin-bottom: 2rem;
+  }
+  
+  .controls {
+    margin-bottom: 2rem;
+  }
+  
+  .tier-toggle {
+    background: linear-gradient(135deg, #10b981, #059669);
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: 12px;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
+  }
+  
+  .tier-toggle:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(16, 185, 129, 0.4);
+  }
+  
+  .comparison-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    gap: 2rem;
+    margin-bottom: 4rem;
+  }
+  
+  .approach-card {
+    background: white;
+    border-radius: 20px;
+    padding: 2rem;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    border: 2px solid #e2e8f0;
+    transition: all 0.3s ease;
+  }
+  
+  .approach-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
+    border-color: #10b981;
+  }
+  
+  .approach-header {
+    margin-bottom: 1.5rem;
+  }
+  
+  .approach-header h2 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #1e293b;
+    margin-bottom: 0.75rem;
+  }
+  
+  .badges {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  
+  .badge {
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.25rem 0.75rem;
+    border-radius: 20px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  
+  .badge.recommended {
+    background: linear-gradient(135deg, #10b981, #059669);
+    color: white;
+  }
+  
+  .badge.animated {
+    background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+    color: white;
+  }
+  
+  .badge.descriptive {
+    background: linear-gradient(135deg, #8b5cf6, #7c3aed);
+    color: white;
+  }
+  
+  .badge.professional {
+    background: linear-gradient(135deg, #6366f1, #4f46e5);
+    color: white;
+  }
+  
+  .badge.accessible {
+    background: linear-gradient(135deg, #f59e0b, #d97706);
+    color: white;
+  }
+  
+  .badge.familiar {
+    background: linear-gradient(135deg, #84cc16, #65a30d);
+    color: white;
+  }
+  
+  .approach-description {
+    margin-bottom: 2rem;
+  }
+  
+  .approach-description p {
+    font-size: 1rem;
+    color: #374151;
+    margin-bottom: 1rem;
+    font-weight: 500;
+  }
+  
+  .approach-description ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  
+  .approach-description li {
+    font-size: 0.9rem;
+    color: #64748b;
+    margin-bottom: 0.5rem;
+    padding-left: 0;
+  }
+  
+  .demo-area {
+    background: #f8fafc;
+    border: 2px dashed #cbd5e1;
+    border-radius: 12px;
+    padding: 2rem;
+    text-align: center;
+  }
+  
+  .demo-label {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #64748b;
+    margin-bottom: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  
+  .issues-section {
+    margin-bottom: 4rem;
+  }
+  
+  .issues-section h2 {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #1e293b;
+    text-align: center;
+    margin-bottom: 2rem;
+  }
+  
+  .issues-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+  }
+  
+  .issue-card {
+    background: white;
+    border-radius: 12px;
+    padding: 1.5rem;
+    border-left: 4px solid #ef4444;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  }
+  
+  .issue-card h3 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #dc2626;
+    margin-bottom: 0.5rem;
+  }
+  
+  .issue-card p {
+    font-size: 0.9rem;
+    color: #64748b;
+    margin: 0;
+  }
+  
+  .tech-notes {
+    margin-bottom: 2rem;
+  }
+  
+  .tech-notes h2 {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #1e293b;
+    text-align: center;
+    margin-bottom: 2rem;
+  }
+  
+  .tech-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+  }
+  
+  .tech-card {
+    background: white;
+    border-radius: 12px;
+    padding: 1.5rem;
+    border-left: 4px solid #10b981;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  }
+  
+  .tech-card h3 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #059669;
+    margin-bottom: 0.5rem;
+  }
+  
+  .tech-card p {
+    font-size: 0.9rem;
+    color: #64748b;
+    margin: 0;
+  }
+  
+  /* Mobile responsive */
+  @media (max-width: 768px) {
+    .demo-page {
+      padding: 1rem;
+    }
+    
+    .demo-header h1 {
+      font-size: 2rem;
+    }
+    
+    .comparison-grid {
+      grid-template-columns: 1fr;
+    }
+    
+    .approach-card {
+      padding: 1.5rem;
+    }
+  }
+</style> 

--- a/src/routes/manage/+page.svelte
+++ b/src/routes/manage/+page.svelte
@@ -269,7 +269,7 @@
 
     {#if showEmailForm}
       <!-- Email Entry Form -->
-      <div class="email-card">
+      <div class="email-card" style="display: none; visibility: hidden;">
         <div class="email-card-content">
           <div class="email-icon">📧</div>
           <h2>Access Your Subscriptions</h2>
@@ -312,7 +312,7 @@
 
       <!-- Magic Link Section -->
       <div class="magic-link-section">
-        <div class="section-divider">
+        <div class="section-divider" style="display: none; visibility: hidden;">
           <span>or</span>
         </div>
         


### PR DESCRIPTION
This PR moves the user email lookup functionality from the public /manage page to behind admin authentication in admin/monitoring.

## Changes Made
-  Added user subscription lookup card to /admin/monitoring page
-  Removed email entry form from public /manage page
-  Preserved magic link and Google auth for regular users
-  Admin can now view/manage any user's subscriptions

## Why This Change
- Restricts powerful user lookup feature to admin-only access
- Simplifies public login flow to just magic link + Google auth  
- Provides admin with direct user management capabilities

## Testing
- Admin can enter any user email and view their subscriptions
- Admin can unsubscribe users from dockets
- Admin can modify user notification frequencies
- Public /manage page now only shows magic link and Google sign-in