### PR TITLE
Add Terms of Service Page

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -62,7 +62,7 @@
              <span>Contact Support</span>
              <span>System Status</span>
              <span>Privacy Policy</span>
-             <span>Terms of Service</span>
+             <a href="/terms-of-service"><span>Terms of Service</span></a>
            </div>
         </div>
         
@@ -147,6 +147,14 @@
      color: rgba(255, 255, 255, 0.7);
      display: block;
      margin-bottom: 0.5rem;
+   }
+   
+   .footer-section a {
+     text-decoration: none;
+   }
+   
+   .footer-section a:hover span {
+     color: var(--color-primary);
    }
   
   .footer-bottom {

--- a/src/routes/terms-of-service/+page.svelte
+++ b/src/routes/terms-of-service/+page.svelte
@@ -1,0 +1,86 @@
+<div class="container">
+  <h1>Terms of Service</h1>
+  <p>Last Updated: 7/27/2025</p>
+
+  <h2>1. Agreement to Terms</h2>
+  <p>By accessing or using DocketCC, you agree to be bound by these Terms of Service. If you do not agree, you may not use the Service.</p>
+
+  <h2>2. Service Description</h2>
+  <p>DocketCC provides FCC regulatory filing notifications via email and AI-generated summaries. The Service includes a free tier and Pro tier ($4.99/month) with a 30-day trial period.</p>
+
+  <h2>3. User Accounts</h2>
+  <p>You must provide accurate information when creating an account. You are responsible for maintaining the security of your account credentials and all activities under your account. You must be at least 18 years old to use the Service.</p>
+
+  <h2>4. Subscription and Payment</h2>
+  <p><strong>Free Tier:</strong> No payment required. Limited features.</p>
+  <p><strong>Pro Tier:</strong> $4.99 monthly subscription fee, billed in advance.</p>
+  <p><strong>Trial Period:</strong> 30-day risk-free trial with full Pro features.</p>
+  <p>Subscription fees are non-refundable except during the trial period. You may cancel at any time, with cancellation effective at the end of the current billing cycle. We reserve the right to modify pricing with thirty (30) days written notice.</p>
+
+  <h2>5. Acceptable Use</h2>
+  <p>You may use the Service only for lawful purposes. You may not:</p>
+  <ul>
+    <li>Resell, redistribute, or transfer access to the Service</li>
+    <li>Use automated systems to access the Service</li>
+    <li>Attempt to gain unauthorized access to our systems</li>
+    <li>Interfere with the operation of the Service</li>
+    <li>Violate any applicable laws or regulations</li>
+  </ul>
+
+  <h2>6. Data and Content</h2>
+  <p>We collect FCC filing data from public government APIs and your account information necessary to provide the Service. FCC filing data remains public information. AI summaries are generated from publicly available regulatory filings.</p>
+
+  <h2>7. Service Availability</h2>
+  <p>We strive to maintain continuous Service availability but do not guarantee uninterrupted access. Service may be affected by third-party dependencies, maintenance, or technical issues.</p>
+
+  <h2>8. Disclaimers</h2>
+  <p>THE SERVICE IS PROVIDED "AS IS" WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED. WE DISCLAIM ALL WARRANTIES INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.</p>
+  <p>The Service provides information only and does not constitute legal, regulatory, or professional advice. We do not guarantee the accuracy or completeness of information provided.</p>
+
+  <h2>9. Limitation of Liability</h2>
+  <p>TO THE MAXIMUM EXTENT PERMITTED BY LAW, OUR LIABILITY SHALL NOT EXCEED THE AMOUNT PAID BY YOU FOR THE SERVICE IN THE TWELVE (12) MONTHS PRECEDING THE CLAIM. WE SHALL NOT BE LIABLE FOR INDIRECT, INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES.</p>
+
+  <h2>10. Indemnification</h2>
+  <p>You agree to indemnify and hold DocketCC harmless from any claims arising from your use of the Service or violation of these Terms.</p>
+
+  <h2>11. Dispute Resolution</h2>
+  <p>Any disputes shall be resolved through binding arbitration under the rules of the American Arbitration Association. You waive any right to participate in class action proceedings.</p>
+
+  <h2>12. Termination</h2>
+  <p>Either party may terminate this agreement at any time. We may suspend or terminate your access for violation of these Terms. Upon termination, your right to use the Service ceases immediately.</p>
+
+  <h2>13. Modifications</h2>
+  <p>We may modify these Terms at any time with reasonable notice. Continued use of the Service constitutes acceptance of modified Terms.</p>
+
+  <h2>14. General Provisions</h2>
+  <p>These Terms constitute the entire agreement between you and DocketCC. If any provision is unenforceable, the remaining provisions remain in effect. These Terms are governed by Georgia law.</p>
+
+  <h2>15. Contact Information</h2>
+  <p>For questions regarding these Terms, contact: docketcc@gmail.com</p>
+</div>
+
+<style>
+  .container {
+    max-width: 800px;
+    margin: 4rem auto;
+    padding: 2rem;
+  }
+  h1 {
+    font-size: var(--font-size-3xl);
+    margin-bottom: 1.5rem;
+  }
+  h2 {
+    font-size: var(--font-size-2xl);
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: 0.5rem;
+  }
+  p, li {
+    line-height: 1.7;
+    margin-bottom: 1rem;
+  }
+  ul {
+    padding-left: 2rem;
+  }
+</style> 


### PR DESCRIPTION
Added a new Terms of Service page with properly formatted content and linked it from the footer. The link has no underline styling but includes a hover effect for better UX.