### PR TITLE
Clean up footer navigation links

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -38,32 +38,18 @@
             <p class="footer-tagline">Stay ahead of regulatory changes that impact your business.</p>
           </div>
           
-                     <div class="footer-section">
-             <h4>Product</h4>
-             <span>Features</span>
-             <span>Pricing</span>
-             <span>API Access</span>
-             <span>Enterprise</span>
-             <span>Security</span>
-           </div>
-           
-           <div class="footer-section">
-             <h4>Resources</h4>
-             <span>Documentation</span>
-             <span>FCC Guide</span>
-             <span>Best Practices</span>
-             <span>Case Studies</span>
-             <span>Blog</span>
-           </div>
-           
-           <div class="footer-section">
-             <h4>Support</h4>
-             <span>Help Center</span>
-             <span>Contact Support</span>
-             <span>System Status</span>
-             <span>Privacy Policy</span>
-             <a href="/terms-of-service"><span>Terms of Service</span></a>
-           </div>
+          <div class="footer-section">
+            <h4>Product</h4>
+            <a href="/about"><span>About</span></a>
+            <a href="/pricing"><span>Pricing</span></a>
+          </div>
+          
+          <div class="footer-section">
+            <h4>Support</h4>
+            <span>Contact Support</span>
+            <span>Privacy Policy</span>
+            <a href="/terms-of-service"><span>Terms of Service</span></a>
+          </div>
         </div>
         
         <div class="footer-bottom">
@@ -113,7 +99,7 @@
   
   .footer-grid {
     display: grid;
-    grid-template-columns: 2fr 1fr 1fr 1fr;
+    grid-template-columns: 2fr 1fr 1fr;
     gap: 3rem;
     margin-bottom: 3rem;
   }
@@ -147,14 +133,6 @@
      color: rgba(255, 255, 255, 0.7);
      display: block;
      margin-bottom: 0.5rem;
-   }
-   
-   .footer-section a {
-     text-decoration: none;
-   }
-   
-   .footer-section a:hover span {
-     color: var(--color-primary);
    }
   
   .footer-bottom {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -129,11 +129,19 @@
     font-size: 1.1rem;
   }
   
-     .footer-section span {
-     color: rgba(255, 255, 255, 0.7);
-     display: block;
-     margin-bottom: 0.5rem;
-   }
+  .footer-section span {
+    color: rgba(255, 255, 255, 0.7);
+    display: block;
+    margin-bottom: 0.5rem;
+  }
+  
+  .footer-section a {
+    text-decoration: none;
+  }
+  
+  .footer-section a:hover span {
+    color: var(--color-primary);
+  }
   
   .footer-bottom {
     border-top: 1px solid #334155;

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,0 +1,58 @@
+<script>
+  // About page - basic structure with no content yet
+</script>
+
+<svelte:head>
+  <title>About - DocketCC</title>
+  <meta name="description" content="Learn more about DocketCC's professional FCC docket monitoring service." />
+</svelte:head>
+
+<div class="about-page">
+  <div class="container">
+    <div class="content">
+      <h1>About</h1>
+      <!-- Content will be added here in the future -->
+    </div>
+  </div>
+</div>
+
+<style>
+  .about-page {
+    min-height: 80vh;
+    padding: 6rem 0 4rem;
+  }
+
+  .container {
+    max-width: var(--max-width-content);
+    margin: 0 auto;
+    padding: 0 var(--spacing-8);
+  }
+
+  .content {
+    max-width: 800px;
+    margin: 0 auto;
+  }
+
+  h1 {
+    color: var(--color-text-primary);
+    font-size: var(--font-size-3xl);
+    font-weight: var(--font-weight-bold);
+    margin-bottom: 2rem;
+    text-align: center;
+  }
+
+  /* Responsive */
+  @media (max-width: 768px) {
+    .about-page {
+      padding: 4rem 0 2rem;
+    }
+    
+    .container {
+      padding: 0 var(--spacing-4);
+    }
+    
+    h1 {
+      font-size: var(--font-size-2xl);
+    }
+  }
+</style>


### PR DESCRIPTION
Updated footer to simplify navigation structure:
- Product section: Only About and Pricing
- Removed Resources section entirely
- Support section: Only Contact Support, Privacy Policy, and Terms of Service
- Adjusted grid layout from 4 to 3 columns
- Created new About page