### PR TITLE
Fix: Update Gemini model to free tier and remove exposed API key

### DIFF
--- a/cron-worker/src/lib/ai/gemini-enhanced.js
+++ b/cron-worker/src/lib/ai/gemini-enhanced.js
@@ -99,7 +99,7 @@ export async function generateEnhancedSummary(filing, documentText = '', env) {
     }
     
     const genAI = new GoogleGenerativeAI(apiKey);
-    const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+    const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-latest" });
     
     // Build enhanced prompt with document content
     const prompt = buildEnhancedPrompt(filing, documentText);

--- a/src/lib/ai/gemini-enhanced.js
+++ b/src/lib/ai/gemini-enhanced.js
@@ -12,14 +12,14 @@ import { env } from '$env/dynamic/private';
 export async function generateEnhancedSummary(filing, documentTexts = [], passedEnv) {
   try {
     // Use SvelteKit native env with fallback support for backwards compatibility
-    const apiKey = env.GEMINI_API_KEY || passedEnv?.GEMINI_API_KEY || process.env.GEMINI_API_KEY || 'AIzaSyCx_57Ec-9CIPOqQMvMC06YLmVYThIW4_w';
+    const apiKey = env.GEMINI_API_KEY || passedEnv?.GEMINI_API_KEY || process.env.GEMINI_API_KEY;
     
     if (!apiKey) {
       throw new Error('GEMINI_API_KEY not found in environment variables');
     }
     
     const genAI = new GoogleGenerativeAI(apiKey);
-    const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+    const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-latest" });
     
     // Build enhanced prompt with document content
     const prompt = buildEnhancedPrompt(filing, documentTexts);

--- a/src/routes/api/test-document-flow/+server.js
+++ b/src/routes/api/test-document-flow/+server.js
@@ -274,7 +274,7 @@ async function generateEnhancedSummaryWithDebug(filing, documentTexts, env) {
   try {
     const { GoogleGenerativeAI } = await import('@google/generative-ai');
     const genAI = new GoogleGenerativeAI(env.GEMINI_API_KEY);
-    const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+    const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-latest" });
     
     const result = await model.generateContent(prompt);
     const rawResponse = result.response.text();


### PR DESCRIPTION
- Change model from 'gemini-1.5-flash' to 'gemini-1.5-flash-latest' in all 3 locations - Remove hardcoded API key fallback for security - Prevents billing charges by using correct free tier model - Fixes security vulnerability of exposed API key in source code