### PR TITLE
Fix: Update email placeholders from organization.gov to domain.com

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -198,7 +198,7 @@
     <h1>F<span class="highlight">CC</span> Docket Intelligence</h1>
     <p class="subtitle">
       Monitoring service for Federal Communications Commission proceedings. 
-      Stay informed with real-time email alerts and AI-powered summaries and analysis of FCC filings.
+      Stay informed with real-time email alerts, AI-powered summaries + analysis of FCC filings.
     </p>
     
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -335,7 +335,7 @@
           <input 
             type="email" 
             class="email-input" 
-            placeholder="your.email@organization.gov"
+            placeholder="your.email@domain.com"
             id="emailInput"
             bind:value={emailInput}
           />

--- a/src/routes/manage/+page.svelte
+++ b/src/routes/manage/+page.svelte
@@ -283,7 +283,7 @@
                 id="email"
                 bind:value={email}
                 class="email-input"
-                placeholder="your.email@organization.gov"
+                placeholder="your.email@domain.com"
                 required
               />
             </div>
@@ -330,7 +330,7 @@
                   id="magic-email"
                   bind:value={magicLinkEmail}
                   class="email-input"
-                  placeholder="your.email@organization.gov"
+                  placeholder="your.email@domain.com"
                   required
                 />
               </div>


### PR DESCRIPTION
Updates email input placeholders across the application from 'your.email@organization.gov' to 'your.email@domain.com' in main page and manage subscriptions page.