### PR TITLE
Clean up pricing page features

### DIFF
--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -288,11 +288,7 @@
     font-size: 0.9rem;
   }
 
-  .features-list li:nth-child(2)::before {
-    content: '+';
-    color: #6b7280;
-    font-weight: 400;
-  }
+
 
   /* Bottom Section */
   .bottom-section {

--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -37,7 +37,6 @@
         <h4 class="features-title">What's included</h4>
         <ul class="features-list">
           <li>1 docket subscription</li>
-          <li>Daily email notifications</li>
           <li>Basic filing metadata</li>
           <li>Document links & access</li>
           <li>Standard support</li>
@@ -68,7 +67,6 @@
         <h4 class="features-title">What's included</h4>
         <ul class="features-list">
           <li>Everything in Free plan</li>
-          <li>+</li>
           <li>Unlimited docket monitoring</li>
           <li>AI-powered summaries</li>
           <li>Instant notifications</li>


### PR DESCRIPTION
Removes unnecessary features from pricing cards:

- Removed 'Daily email notifications' from Free plan features
- Removed '+' line from Pro plan features

This makes the pricing page cleaner and more focused on the core value propositions.